### PR TITLE
Geotargeting EU users, update consent string to 1.1 standard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@
     "jest/no-identical-title": 2,
     "no-empty": 0,
     "no-console": 0,
+    "no-unused-vars": 1,
     "no-empty-pattern": 0,
     "no-cond-assign": 1,
     "semi": 1,

--- a/.eslintrc
+++ b/.eslintrc
@@ -79,7 +79,7 @@
     "no-const-assign": 2,
     "prefer-spread": 2,
     "no-useless-concat": 2,
-    "no-var": 2,
+    "no-var": 0,
     "object-shorthand": 2,
     "prefer-arrow-callback": 2
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,4 @@
+{
+  "cmpVersion": 1,
+  "cmpId": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
   "name": "digitrust-cmp",
-  "cmpVersion": 1,
-  "cmpId": 1,
   "version": "0.0.0",
   "scripts": {
     "clean": "rm -rf build",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "digitrust-cmp",
+  "cmpVersion": 1,
+  "cmpId": 1,
   "version": "0.0.0",
   "scripts": {
     "clean": "rm -rf build",

--- a/src/components/popup/popup.jsx
+++ b/src/components/popup/popup.jsx
@@ -34,8 +34,7 @@ export default class Popup extends Component {
 	};
 
 	handleClose = () => {
-		const { store, onSave } = this.props;
-		onSave();
+		const { store } = this.props;
 		store.toggleFooterShowing(true);
 	};
 

--- a/src/docs/assets/portal.js
+++ b/src/docs/assets/portal.js
@@ -12,13 +12,13 @@ const COOKIE_NAME = 'euconsent';
 
 const readVendorListPromise = fetch(LOCAL_VENDOR_LIST_DOMAIN)
 	.then(res => res.json())
-	.catch(err => {
+	.catch(() => {
 		log.error(`Failed to load local vendor list from vendors.json, trying global`);
 		return fetch(GLOBAL_VENDOR_LIST_DOMAIN)
 			.then(resp => resp.json())
 			.catch(error => {
-				log.error(`Failed to load global vendor list`, err);
-			})
+				log.error(`Failed to load global vendor list`, error);
+			});
 	});
 
 function readCookie(name) {

--- a/src/docs/assets/vendors.json
+++ b/src/docs/assets/vendors.json
@@ -1,48 +1,94 @@
 {
   "version": 1,
-  "origin": "http://ib.adnxs.com/vendors.json",
-  "purposes": [
-	{
-	  "id": 1,
-	  "name": "Accessing a Device or Browser"
-	},
-	{
-	  "id": 2,
-	  "name": "Advertising Personalisation"
-	},
-	{
-	  "id": 3,
-	  "name": "Analytics"
-	},
-	{
-	  "id": 4,
-	  "name": "Content Personalisation"
-	}
-  ],
+  "lastUpdated":"2018-04-30T16:04:20Z",
+  "origin": "https://vendorlist.consensu.org/vendorlist.json",
+	"purposes":[
+		{
+			"id":1,
+			"name":"Storage and access of information",
+			"description":"The storage of information, or access to information that is already stored, on your device such as accessing advertising identifiers and/or other device identifiers, and/or using cookies or similar technologies."
+		},
+		{
+			"id":2,
+			"name":"Personalisation",
+			"description":"The collection and processing of information about your use of this site to subsequently personalize advertising for you in other contexts, i.e. on other sites or apps, over time. Typically, the content of the site or app is used to make inferences about your interests which inform future selections."
+		},
+		{
+			"id":3,
+			"name":"Ad selection, delivery, reporting",
+			"description":"The collection of information, and combination with previously collected information, to select and deliver advertisements for you, and to measure the delivery and effectiveness of such advertisements. This includes using previously collected information about your interests to select ads, processing data about what advertisements were shown, how often they were shown, when and where they were shown, and whether you took any action related to the advertisement, including for example clicking an ad or making a purchase. "
+		},
+		{
+			"id":4,
+			"name":"Content selection, delivery, reporting",
+			"description":"The collection of information, and combination with previously collected information, to select and deliver content for you, and to measure the delivery and effectiveness of such content. This includes using previously collected information about your interests to select content, processing data about what content was shown, how often or how long it was shown, when and where it was shown, and whether the you took any action related to the content, including for example clicking on content. "
+		},
+		{
+			"id":5,
+			"name":"Measurement",
+			"description":"The collection of information about your use of the content, and combination with previously collected information, used to measure, understand, and report on your usage of the content."
+		}
+	],
+	"features":[
+		{
+			"id":1,
+			"name":"Matching Data to Offline Sources",
+			"description":"Combining data from offline sources that were initially collected in other contexts."
+		},
+		{
+			"id":2,
+			"name":"Linking Devices",
+			"description":"Allow processing of a user's data to connect such user across multiple devices."
+		},
+		{
+			"id":3,
+			"name":"Precise Geographic Location Data",
+			"description":"Allow processing of a user's precise geographic location data in support of a purpose for which that certain third party has consent."
+		}
+	],
   "vendors": [
 	{
 	  "id": 1,
-	  "name": "Globex"
+	  "name": "Globex",
+	  "policyUrl":"https://www.example.com/",
+	  "purposeIds": [1,2,4],
+	  "legIntPurposeIds": [3,5],
+	  "featureIds":[1,2]
 	},
 	{
 	  "id": 2,
-	  "name": "Initech"
+	  "name": "Initech",
+		"purposeIds":[1,3,5],
+		"legIntPurposeIds":[],
+		"featureIds":[3]
 	},
 	{
 	  "id": 3,
-	  "name": "CRS"
+	  "name": "CRS",
+		"purposeIds":[1,2,3,4,5],
+		"legIntPurposeIds":[],
+		"featureIds":[1,2,3]
 	},
 	{
 	  "id": 4,
-	  "name": "Umbrella"
+	  "name": "Umbrella",
+		"purposeIds":[1,3,5],
+		"legIntPurposeIds":[4],
+		"featureIds":[1,3]
 	},
 	{
 	  "id": 5,
-	  "name": "Aperture"
+	  "name": "Aperture",
+		"purposeIds":[1,3,5],
+		"legIntPurposeIds":[],
+		"featureIds":[3]
 	},
 	{
 	  "id": 6,
-	  "name": "Pierce and Pierce"
+	  "name": "Pierce and Pierce",
+		"purposeIds":[1,3,5],
+		"legIntPurposeIds":[],
+		"featureIds":[3]
 	}
   ]
 }

--- a/src/docs/components/tools/cookieEncoder.jsx
+++ b/src/docs/components/tools/cookieEncoder.jsx
@@ -85,6 +85,12 @@ export default class CookieEncoder extends Component {
 					}
 					break;
 				}
+				case '6bitchar': {
+					if (text.match(/[A-z]*/)) {
+						_.set(decodedObject, propertyPath, text);
+					}
+					break;
+				}
 			}
 
 			this.setState({
@@ -144,6 +150,7 @@ export default class CookieEncoder extends Component {
 					onChange={this.handleInputChanged(field, objectPath)}
 					isSelected={_.get(decodedObject, propertyPath, false)}
 				/>;
+			case '6bitchar':
 			case 'int':
 			case 'bits':
 				return <input
@@ -214,7 +221,6 @@ export default class CookieEncoder extends Component {
 						if (!validator || validator(fieldObject)) {
 							const listEntryCount = typeof listCount === 'function' ?
 								listCount(fieldObject) : typeof listCount === 'number' ? listCount : 0;
-
 							for (let i = 0; i < listEntryCount; i++) {
 								_.forEach(field.fields, f => {
 									rows.push(this.renderInputRow(f, _.filter([objectPath, name, `[${i}]`]).join('.')));

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -2,6 +2,7 @@ import log from './log';
 import Promise from 'promise-polyfill';
 import { encodeVendorConsentData } from './cookie/cookie';
 import 'whatwg-fetch';
+
 const metadata = require('../../metadata.json');
 
 const MAX_COOKIE_LIFESPAN_DAYS = 390;
@@ -144,12 +145,16 @@ export default class Cmp {
 			return false;
 		},
 		checkIfUserInEU: () => {
-			const config = this.config;
+			const self = this;
 
-			return fetch(config.geoIPVendor)
+			return fetch(self.config.geoIPVendor)
 				.then(resp => {
 				  let countryISO = resp.headers.get("X-GeoIP-Country");
-				  return EU_COUNTRY_CODES.has(countryISO);
+				  if (EU_COUNTRY_CODES.has(countryISO)) {
+						self.store.updateIsEU(true);
+						return true;
+				  }
+				  return false;
 				});
 		},
 		getAmountOfConsentGiven: (vendorConsents, totalPossibleVendors) => {

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -2,7 +2,7 @@ import log from './log';
 import Promise from 'promise-polyfill';
 import { encodeVendorConsentData } from './cookie/cookie';
 import 'whatwg-fetch';
-const pack = require('../../package.json');
+const metadata = require('../../metadata.json');
 
 const MAX_COOKIE_LIFESPAN_DAYS = 390;
 const EU_COUNTRY_CODES = new Set([
@@ -107,7 +107,7 @@ const EU_LANGUAGE_CODES = new Set([
 	"br",
 	"eo",
 ]);
-const CMP_VERSION = pack.cmpVersion;
+const CMP_VERSION = metadata.cmpVersion;
 export const CMP_GLOBAL_NAME = '__cmp';
 
 export default class Cmp {

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -203,7 +203,7 @@ export default class Cmp {
 					let needsGlobalCookie = false;
 					if (config.storeConsentGlobally && !store.getVendorConsentsObject().lastUpdated) needsGlobalCookie = true;
 
-					if (config.hasGlobalScope) {
+					if (config.gdprAppliesGlobally) {
 						// if no cookie, show tool
 						if (needsPublisherCookie || needsGlobalCookie) {
 							cmp('showConsentTool');

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -1,6 +1,6 @@
 import log from './log';
 import Promise from 'promise-polyfill';
-import { encodeVendorConsentData, readGlobalVendorConsentCookie } from './cookie/cookie';
+import { encodeVendorConsentData } from './cookie/cookie';
 import 'whatwg-fetch';
 const pack = require('../../package.json');
 
@@ -107,7 +107,7 @@ const EU_LANGUAGE_CODES = new Set([
 	"br",
 	"eo",
 ]);
-const CMP_VERSION = pack.version;
+const CMP_VERSION = pack.cmpVersion;
 export const CMP_GLOBAL_NAME = '__cmp';
 
 export default class Cmp {
@@ -197,7 +197,7 @@ export default class Cmp {
 				Promise.all([
 					cmp('getVendorConsents'),
 					cmp('getVendorList')
-				]).then(([{vendorConsents, vendorListVersion}, {vendors}]) => {
+				]).then(([{vendorConsents}, {vendors}]) => {
 					let needsPublisherCookie = false;
 					if (config.storePublisherData && !store.getPublisherConsentsObject().lastUpdated) needsPublisherCookie = true;
 					let needsGlobalCookie = false;

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -256,9 +256,11 @@ export default class Cmp {
 		 * @param {Array} vendorIds Array of vendor IDs to retrieve.  If empty return all vendors.
 		 */
 		getVendorConsents: (vendorIds, callback = () => {}) => {
-			const consent = this.store.getVendorConsentsObject(vendorIds);
-			callback(consent);
-			return consent;
+			return this.store.getFullVendorConsentsObject(vendorIds)
+				.then(consent => {
+					callback(consent);
+					return consent;
+				});
 		},
 
 		/**

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -1,8 +1,8 @@
 import log from './log';
 import Promise from 'promise-polyfill';
-import pack from '../../package.json';
-import { encodeVendorConsentData } from './cookie/cookie';
+import { encodeVendorConsentData, readGlobalVendorConsentCookie } from './cookie/cookie';
 import 'whatwg-fetch';
+const pack = require('../../package.json');
 
 const MAX_COOKIE_LIFESPAN_DAYS = 390;
 const EU_COUNTRY_CODES = new Set([
@@ -197,9 +197,7 @@ export default class Cmp {
 				Promise.all([
 					cmp('getVendorConsents'),
 					cmp('getVendorList')
-				]).then(([{vendorConsents}, {vendors}]) => {
-					// Can also grab vendorListVersion from the first promise here ^^
-
+				]).then(([{vendorConsents, vendorListVersion}, {vendors}]) => {
 					let needsPublisherCookie = false;
 					if (config.storePublisherData && !store.getPublisherConsentsObject().lastUpdated) needsPublisherCookie = true;
 					let needsGlobalCookie = false;

--- a/src/lib/cmp.test.js
+++ b/src/lib/cmp.test.js
@@ -117,6 +117,8 @@ describe('cmp', () => {
 					lastUpdated: nonExpiredDate
 				};
 				expect(cmp.utils.checkIfCookieIsOld(3)).eq(false);
+
+				expect(cmp.utils.checkIfCookieIsOld(undefined)).eq(false);
 			});
 		});
 	});

--- a/src/lib/cmp.test.js
+++ b/src/lib/cmp.test.js
@@ -154,7 +154,7 @@ describe('cmp', () => {
 
 		it('getVendorConsents executes', (done) => {
 			cmp.processCommand('getVendorConsents', null, data => {
-				expect(Object.keys(data.purposes).length).to.equal(vendorList.purposes.length);
+				expect(Object.keys(data.purposeConsents).length).to.equal(vendorList.purposes.length);
 				expect(Object.keys(data.vendorConsents).length).to.equal(vendorList.vendors.length);
 				done();
 			});

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -8,7 +8,7 @@ const defaultConfig = {
 	logging: false,
 	localization: {},
 	forceLocale: null,
-	hasGlobalScope: false,
+	gdprAppliesGlobally: false,
 	repromptOptions: {
 		fullConsentGiven: 360,
 		someConsentGiven: 30,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -14,6 +14,7 @@ const defaultConfig = {
 		someConsentGiven: 30,
 		noConsentGiven: 30,
 	},
+	geoIPVendor: 'http://cmp.digitru.st/geoip-demo.html',
 };
 
 class Config {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -10,7 +10,7 @@ const defaultConfig = {
 	forceLocale: null,
 	hasGlobalScope: false,
 	repromptOptions: {
-		fullConsentGiven: 30,
+		fullConsentGiven: 360,
 		someConsentGiven: 30,
 		noConsentGiven: 30,
 	},

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -14,7 +14,7 @@ const defaultConfig = {
 		someConsentGiven: 30,
 		noConsentGiven: 30,
 	},
-	geoIPVendor: 'http://cmp.digitru.st/geoip-demo.html',
+	geoIPVendor: 'http://cmp.digitru.st/geoip.json',
 };
 
 class Config {

--- a/src/lib/cookie/cookie.js
+++ b/src/lib/cookie/cookie.js
@@ -10,7 +10,7 @@ import {
 
 import { sendPortalCommand } from '../portal';
 import config from '../config';
-const pack = require('../../../package.json');
+const metadata = require('../../../metadata.json');
 
 const PUBLISHER_CONSENT_COOKIE_NAME = 'pubconsent';
 const PUBLISHER_CONSENT_COOKIE_MAX_AGE = 33696000;
@@ -123,6 +123,7 @@ function decodeVendorConsentData(cookieValue) {
 	} = decodeVendorCookieValue(cookieValue);
 
 	const cookieData = {
+		consentString: cookieValue,
 		cookieVersion,
 		cmpId,
 		cmpVersion,
@@ -134,6 +135,7 @@ function decodeVendorConsentData(cookieValue) {
 		created,
 		lastUpdated
 	};
+
 
 	if (isRange) {
 		const idMap = vendorRangeList.reduce((acc, {isRange, startVendorId, endVendorId}) => {
@@ -268,7 +270,7 @@ function writeGlobalVendorConsentCookie(vendorConsentData) {
 		command: 'writeVendorConsent',
 		encodedValue: encodeVendorConsentData(vendorConsentData),
 		vendorConsentData,
-		cmpVersion: pack.cmpVersion
+		cmpVersion: metadata.cmpVersion
 	}).catch(err => {
 		log.error('Failed writing global vendor consent cookie', err);
 	});

--- a/src/lib/cookie/cookie.js
+++ b/src/lib/cookie/cookie.js
@@ -104,7 +104,7 @@ function encodeVendorConsentData(vendorData) {
 	return noRangesData.length < rangesData.length ? noRangesData : rangesData;
 }
 
-function decodeVendorConsentData(cookieValue) {
+function decodeVendorConsentData(cookieValue, source) {
 	const {
 		cookieVersion,
 		cmpId,
@@ -124,6 +124,7 @@ function decodeVendorConsentData(cookieValue) {
 
 	const cookieData = {
 		consentString: cookieValue,
+		source,
 		cookieVersion,
 		cmpId,
 		cmpVersion,
@@ -251,7 +252,7 @@ function readGlobalVendorConsentCookie() {
 	}).then(result => {
 		log.debug('Read consent data from global cookie', result);
 		if (result) {
-			return decodeVendorConsentData(result);
+			return decodeVendorConsentData(result, "global");
 		}
 	}).catch(err => {
 		log.error('Failed reading global vendor consent cookie', err);
@@ -285,7 +286,7 @@ function writeGlobalVendorConsentCookie(vendorConsentData) {
 function readLocalVendorConsentCookie() {
 	const cookie = readCookie(VENDOR_CONSENT_COOKIE_NAME);
 	log.debug('Read consent data from local cookie', cookie);
-	return Promise.resolve(cookie && decodeVendorConsentData(cookie));
+	return Promise.resolve(cookie && decodeVendorConsentData(cookie, "local"));
 }
 
 /**

--- a/src/lib/cookie/cookie.js
+++ b/src/lib/cookie/cookie.js
@@ -72,13 +72,16 @@ function convertVendorsToRanges(vendors, selectedIds) {
 }
 
 function encodeVendorConsentData(vendorData) {
-	const {vendorList = {}, selectedPurposeIds, selectedVendorIds, maxVendorId} = vendorData;
+	const {vendorList = {}, selectedPurposeIds, selectedVendorIds, maxVendorId, cmpId, cmpVersion, cookieVersion} = vendorData;
 	const {vendors = [], purposes = []} = vendorList;
 
 	// Encode the data with and without ranges and return the smallest encoded payload
 	const noRangesData = encodeVendorCookieValue({
 		...vendorData,
 		maxVendorId,
+		cmpId,
+		cmpVersion,
+		cookieVersion,
 		purposeIdBitString: encodePurposeIdsToBits(purposes, selectedPurposeIds),
 		isRange: false,
 		vendorIdBitString: encodeVendorIdsToBits(maxVendorId, selectedVendorIds)
@@ -88,6 +91,9 @@ function encodeVendorConsentData(vendorData) {
 	const rangesData = encodeVendorCookieValue({
 		...vendorData,
 		maxVendorId,
+		cmpId,
+		cmpVersion,
+		cookieVersion,
 		purposeIdBitString: encodePurposeIdsToBits(purposes, selectedPurposeIds),
 		isRange: true,
 		defaultConsent: false,
@@ -262,7 +268,7 @@ function writeGlobalVendorConsentCookie(vendorConsentData) {
 		command: 'writeVendorConsent',
 		encodedValue: encodeVendorConsentData(vendorConsentData),
 		vendorConsentData,
-		cmpVersion: pack.version
+		cmpVersion: pack.cmpVersion
 	}).catch(err => {
 		log.error('Failed writing global vendor consent cookie', err);
 	});

--- a/src/lib/cookie/cookie.js
+++ b/src/lib/cookie/cookie.js
@@ -9,8 +9,8 @@ import {
 } from './cookieutils';
 
 import { sendPortalCommand } from '../portal';
-import pack from '../../../package.json';
 import config from '../config';
+const pack = require('../../../package.json');
 
 const PUBLISHER_CONSENT_COOKIE_NAME = 'pubconsent';
 const PUBLISHER_CONSENT_COOKIE_MAX_AGE = 33696000;

--- a/src/lib/cookie/cookie.test.js
+++ b/src/lib/cookie/cookie.test.js
@@ -13,6 +13,7 @@ import {
 	writePublisherConsentCookie,
 	readPublisherConsentCookie,
 	readVendorConsentCookie,
+	convertVendorsToRanges,
 	PUBLISHER_CONSENT_COOKIE_NAME,
 	VENDOR_CONSENT_COOKIE_NAME
 } from './cookie';
@@ -59,12 +60,12 @@ const vendorList = {
 			"name": "Umbrella"
 		},
 		{
-			"id": 5,
-			"name": "Aperture"
-		},
-		{
 			"id": 6,
 			"name": "Pierce and Pierce"
+		},
+		{
+			"id": 5,
+			"name": "Aperture"
 		}
 	]
 };
@@ -89,6 +90,9 @@ describe('cookie', () => {
 		const vendorConsentData = {
 			cookieVersion: 1,
 			cmpId: 1,
+			cmpVersion: 1,
+			consentScreen: 2,
+			consentLanguage: 'DE',
 			vendorListVersion: 1,
 			maxVendorId: vendorList.vendors[vendorList.vendors.length - 1].id,
 			created: aDate,
@@ -97,7 +101,7 @@ describe('cookie', () => {
 			selectedVendorIds: new Set([1, 2, 4])
 		};
 
-		const encodedString = encodeVendorConsentData({ ...vendorConsentData, vendorList });
+		const encodedString = encodeVendorConsentData({...vendorConsentData, vendorList});
 		const decoded = decodeVendorConsentData(encodedString);
 
 		expect(decoded).to.deep.equal(vendorConsentData);
@@ -130,7 +134,7 @@ describe('cookie', () => {
 		});
 		const decoded = decodePublisherConsentData(encodedString);
 
-		expect(decoded).to.deep.equal({ ...vendorConsentData, ...publisherConsentData });
+		expect(decoded).to.deep.equal({...vendorConsentData, ...publisherConsentData});
 	});
 
 	it('writes and reads the local cookie when globalConsent = false', () => {
@@ -211,5 +215,15 @@ describe('cookie', () => {
 
 		expect(document.cookie).to.contain(PUBLISHER_CONSENT_COOKIE_NAME);
 		expect(fromCookie).to.deep.include(publisherConsentData);
+	});
+
+	it('converts selected vendor list to a range', () => {
+		const ranges = convertVendorsToRanges(vendorList.vendors, new Set([2, 3, 4, 5]));
+
+		expect(ranges).to.deep.equal([{
+			isRange: true,
+			startVendorId: 2,
+			endVendorId: 5
+		}]);
 	});
 });

--- a/src/lib/cookie/cookie.test.js
+++ b/src/lib/cookie/cookie.test.js
@@ -102,8 +102,8 @@ describe('cookie', () => {
 		};
 
 		const encodedString = encodeVendorConsentData({...vendorConsentData, vendorList});
-		const decoded = decodeVendorConsentData(encodedString);
-		const output = Object.assign({consentString: encodedString}, vendorConsentData);
+		const decoded = decodeVendorConsentData(encodedString, "local");
+		const output = Object.assign({consentString: encodedString, source: "local"}, vendorConsentData);
 
 		expect(decoded).to.deep.equal(output);
 	});

--- a/src/lib/cookie/cookie.test.js
+++ b/src/lib/cookie/cookie.test.js
@@ -103,8 +103,9 @@ describe('cookie', () => {
 
 		const encodedString = encodeVendorConsentData({...vendorConsentData, vendorList});
 		const decoded = decodeVendorConsentData(encodedString);
+		const output = Object.assign({consentString: encodedString}, vendorConsentData);
 
-		expect(decoded).to.deep.equal(vendorConsentData);
+		expect(decoded).to.deep.equal(output);
 	});
 
 	it('encodes and decodes the publisher cookie object back to original value', () => {

--- a/src/lib/cookie/cookieutils.test.js
+++ b/src/lib/cookie/cookieutils.test.js
@@ -4,13 +4,15 @@ import {
 	encodeIntToBits,
 	encodeBoolToBits,
 	encodeDateToBits,
+	encode6BitCharacters,
 	decodeBitsToInt,
 	decodeBitsToDate,
 	decodeBitsToBool,
 	encodeVendorCookieValue,
 	decodeVendorCookieValue,
 	encodePublisherCookieValue,
-	decodePublisherCookieValue
+	decodePublisherCookieValue,
+	decode6BitCharacters
 } from './cookieutils';
 
 describe('cookieutils', () => {
@@ -51,6 +53,13 @@ describe('cookieutils', () => {
 		});
 	});
 
+	describe('encode6BitCharacters', () => {
+		it('encode a 6bitchar string to a bit string', () => {
+			const bitString = encode6BitCharacters('hello');
+			expect(bitString).to.equal('000111000100001011001011001110');
+		});
+	});
+
 	describe('decodeBitsToInt', () => {
 		it('decodes a bit string to original encoded value', () => {
 			const bitString = encodeIntToBits(123);
@@ -78,6 +87,21 @@ describe('cookieutils', () => {
 			const bitString = encodeBoolToBits(false);
 			const decoded = decodeBitsToBool(bitString, 0, bitString.length);
 			expect(decoded).to.equal(false);
+		});
+	});
+
+	describe('decode6BitCharacters', () => {
+		it('decodes a bit string to original encoded value', () => {
+			const string = 'STUFF';
+			const bitString = encode6BitCharacters(string);
+			const decoded = decode6BitCharacters(bitString, 0, bitString.length);
+			expect(decoded).to.equal(string);
+		});
+		it('decodes a bit string that is longer than length', () => {
+			const string = 'STUFF';
+			const bitString = encode6BitCharacters(string);
+			const decoded = decode6BitCharacters(bitString, 0, 12);
+			expect(decoded).to.equal('ST');
 		});
 	});
 
@@ -127,6 +151,9 @@ describe('cookieutils', () => {
 			created: aDate,
 			lastUpdated: aDate,
 			cmpId: 1,
+			cmpVersion: 1,
+			consentScreen: 1,
+			consentLanguage: 'EN',
 			vendorListVersion: 1,
 			purposeIdBitString: '111000001010101010001101',
 			maxVendorId: 5,
@@ -161,6 +188,9 @@ describe('cookieutils', () => {
 			created: aDate,
 			lastUpdated: aDate,
 			cmpId: 1,
+			cmpVersion: 1,
+			consentScreen: 1,
+			consentLanguage: 'EN',
 			vendorListVersion: 1,
 			purposeIdBitString: '111000001010101010001101',
 			maxVendorId: 5,
@@ -194,6 +224,9 @@ describe('cookieutils', () => {
 			created: aDate,
 			lastUpdated: aDate,
 			cmpId: 1,
+			cmpVersion: 1,
+			consentScreen: 1,
+			consentLanguage: 'EN',
 			vendorListVersion: 1,
 			purposeIdBitString: '000000001010101010001100',
 			maxVendorId: 5,

--- a/src/lib/cookie/definitions/vendor/version1.js
+++ b/src/lib/cookie/definitions/vendor/version1.js
@@ -5,6 +5,9 @@ export default {
 		{ name: 'created', type: 'date', numBits: 36 },
 		{ name: 'lastUpdated', type: 'date', numBits: 36 },
 		{ name: 'cmpId', type: 'int', numBits: 12 },
+		{ name: 'cmpVersion', type: 'int', numBits: 12 },
+		{ name: 'consentScreen', type: 'int', numBits: 6 },
+		{ name: 'consentLanguage', type: '6bitchar', numBits: 12 },
 		{ name: 'vendorListVersion', type: 'int', numBits: 12 },
 		{ name: 'purposeIdBitString', type: 'bits', numBits: 24 },
 		{ name: 'maxVendorId', type: 'int', numBits: 16 },
@@ -53,4 +56,3 @@ export default {
 		}
 	]
 };
-

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -5,9 +5,8 @@ import Cmp, { CMP_GLOBAL_NAME } from './cmp';
 import { readVendorConsentCookie, readPublisherConsentCookie } from './cookie/cookie';
 import { fetchVendorList, fetchPurposeList } from './vendor';
 import log from './log';
-import pack from '../../package.json';
 import config from './config';
-
+const pack = require('../../package.json');
 
 export function init(configUpdates) {
 	config.update(configUpdates);
@@ -18,7 +17,13 @@ export function init(configUpdates) {
 		.then(vendorConsentData => {
 
 			// Initialize the store with all of our consent data
-			const store = new Store({vendorConsentData, publisherConsentData: readPublisherConsentCookie()});
+			const store = new Store({
+				vendorConsentData,
+				publisherConsentData: readPublisherConsentCookie(),
+				cmpId: 1,
+				cmpVersion: pack.version,
+				cookieVersion: 1
+			});
 
 			// Request lists
 			return Promise.all([

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -20,8 +20,8 @@ export function init(configUpdates) {
 			const store = new Store({
 				vendorConsentData,
 				publisherConsentData: readPublisherConsentCookie(),
-				cmpId: 1,
-				cmpVersion: pack.version,
+				cmpId: pack.cmpId,
+				cmpVersion: pack.cmpVersion,
 				cookieVersion: 1
 			});
 
@@ -62,7 +62,7 @@ export function init(configUpdates) {
 				render(<App store={store} notify={cmp.notify} />, document.body);
 
 				// Notify listeners that the CMP is loaded
-				log.debug(`Successfully loaded CMP version: ${pack.version}`);
+				log.debug(`Successfully loaded CMP version: ${pack.cmpVersion}`);
 				cmp.isLoaded = true;
 				cmp.notify('isLoaded');
 				cmp.cmpReady = true;

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -6,7 +6,7 @@ import { readVendorConsentCookie, readPublisherConsentCookie } from './cookie/co
 import { fetchVendorList, fetchPurposeList } from './vendor';
 import log from './log';
 import config from './config';
-const pack = require('../../package.json');
+const metadata = require('../../metadata.json');
 
 export function init(configUpdates) {
 	config.update(configUpdates);
@@ -20,8 +20,8 @@ export function init(configUpdates) {
 			const store = new Store({
 				vendorConsentData,
 				publisherConsentData: readPublisherConsentCookie(),
-				cmpId: pack.cmpId,
-				cmpVersion: pack.cmpVersion,
+				cmpId: metadata.cmpId,
+				cmpVersion: metadata.cmpVersion,
 				cookieVersion: 1
 			});
 
@@ -62,7 +62,7 @@ export function init(configUpdates) {
 				render(<App store={store} notify={cmp.notify} />, document.body);
 
 				// Notify listeners that the CMP is loaded
-				log.debug(`Successfully loaded CMP version: ${pack.cmpVersion}`);
+				log.debug(`Successfully loaded CMP version: ${metadata.cmpVersion}`);
 				cmp.isLoaded = true;
 				cmp.notify('isLoaded');
 				cmp.cmpReady = true;

--- a/src/lib/localize.js
+++ b/src/lib/localize.js
@@ -1,7 +1,7 @@
 import translations from './translations';
 import config from './config';
 
-function findLocale() {
+export function findLocale() {
 	const locale = config.forceLocale ||
 		(navigator && (
 			navigator.language ||

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,4 +1,8 @@
-import { writePublisherConsentCookie, writeVendorConsentCookie } from "./cookie/cookie";
+import {
+	writePublisherConsentCookie,
+	writeVendorConsentCookie,
+	readVendorConsentCookie
+} from "./cookie/cookie";
 import config from './config';
 import { findLocale } from './localize';
 const metadata = require('../../metadata.json');
@@ -136,6 +140,30 @@ export default class Store {
 			vendorConsents: vendorMap
 		};
 	};
+
+	getFullVendorConsentsObject = () => {
+		const self = this;
+		return readVendorConsentCookie().then(cookie => {
+			var isEU;
+			var consentString;
+			var source;
+			var consentScreen;
+
+			if (cookie) {
+				isEU = cookie.isEU;
+				consentString = cookie.consentString;
+				source = cookie.source;
+				consentScreen = cookie.consentScreen;
+			}
+
+			return Object.assign(self.getVendorConsentsObject(), {
+				isEU,
+				consentString,
+				source,
+				consentScreen
+			});
+		});
+	}
 
 	/**
 	 * Build publisher consent object from data that has already been persisted.

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,6 +1,7 @@
 import { writePublisherConsentCookie, writeVendorConsentCookie } from "./cookie/cookie";
 import config from './config';
 import { findLocale } from './localize';
+const pack = require('../../package.json');
 
 /**
  * Copy a data object and make sure to replace references
@@ -21,8 +22,8 @@ function copyData(dataObject) {
 
 export default class Store {
 	constructor({
-		cmpId = 1,
-		cmpVersion = 1,
+		cmpId = pack.cmpId,
+		cmpVersion = pack.cmpVersion,
 		cookieVersion = 1,
 		vendorConsentData,
 		publisherConsentData,
@@ -67,9 +68,9 @@ export default class Store {
 		} = this;
 
 		const {
-			cookieVersion,
 			created,
 			lastUpdated,
+			cookieVersion,
 			cmpId,
 			cmpVersion,
 			consentScreen,

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -40,7 +40,8 @@ export default class Store {
 			cmpVersion,
 			consentLanguage: findLocale().substr(0, 2).toUpperCase(),
 			selectedPurposeIds: new Set(),
-			selectedVendorIds: new Set()
+			selectedVendorIds: new Set(),
+			isEU: null
 		}, vendorConsentData);
 
 		this.publisherConsentData = Object.assign({
@@ -68,7 +69,9 @@ export default class Store {
 		} = this;
 
 		const {
+			isEU,
 			consentString,
+			source,
 			created,
 			lastUpdated,
 			cookieVersion,
@@ -117,7 +120,9 @@ export default class Store {
 		}
 
 		return {
+			isEU,
 			consentString,
+			source,
 			cookieVersion,
 			created,
 			lastUpdated,
@@ -356,4 +361,15 @@ export default class Store {
 		this.customPurposeList = customPurposeList;
 		this.storeUpdate();
 	};
+
+	updateIsEU = boolean => {
+		const {
+			vendorConsentData,
+		} = this;
+
+		this.vendorConsentData.isEU = boolean;
+
+		// Store the persisted data
+		this.persistedVendorConsentData = copyData(vendorConsentData);
+	}
 }

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,7 +1,7 @@
 import { writePublisherConsentCookie, writeVendorConsentCookie } from "./cookie/cookie";
 import config from './config';
 import { findLocale } from './localize';
-const pack = require('../../package.json');
+const metadata = require('../../metadata.json');
 
 /**
  * Copy a data object and make sure to replace references
@@ -22,8 +22,8 @@ function copyData(dataObject) {
 
 export default class Store {
 	constructor({
-		cmpId = pack.cmpId,
-		cmpVersion = pack.cmpVersion,
+		cmpId = metadata.cmpId,
+		cmpVersion = metadata.cmpVersion,
 		cookieVersion = 1,
 		vendorConsentData,
 		publisherConsentData,
@@ -68,6 +68,7 @@ export default class Store {
 		} = this;
 
 		const {
+			consentString,
 			created,
 			lastUpdated,
 			cookieVersion,
@@ -116,6 +117,7 @@ export default class Store {
 		}
 
 		return {
+			consentString,
 			cookieVersion,
 			created,
 			lastUpdated,

--- a/src/lib/store.test.js
+++ b/src/lib/store.test.js
@@ -114,13 +114,12 @@ describe('store', () => {
 		const vendorObject = store.getVendorConsentsObject();
 		const noConsentVendorCount = Object.keys(vendorObject.vendorConsents).filter(key => !vendorObject.vendorConsents[key]).length;
 
-
 		expect(noConsentVendorCount).to.equal(vendorList.vendors.length - 2);
 		expect(vendorObject.vendorConsents['4']).to.be.true;
 		expect(vendorObject.vendorConsents['5']).to.be.true;
 
-		expect(vendorObject.purposes['1']).to.be.true;
-		expect(vendorObject.purposes['4']).to.be.true;
+		expect(vendorObject.purposeConsents['1']).to.be.true;
+		expect(vendorObject.purposeConsents['4']).to.be.true;
 	});
 
 	it('returns consent=false for vendors that are not in the vendorList', () => {
@@ -152,10 +151,10 @@ describe('store', () => {
 
 		const vendorObject = store.getVendorConsentsObject();
 
-		expect(vendorObject.purposes['1']).to.be.true;
-		expect(vendorObject.purposes['4']).to.be.true;
-		expect(vendorObject.purposes['9']).to.be.false;
-		expect(vendorObject.purposes['10']).to.be.false;
+		expect(vendorObject.purposeConsents['1']).to.be.true;
+		expect(vendorObject.purposeConsents['4']).to.be.true;
+		expect(vendorObject.purposeConsents['9']).to.be.false;
+		expect(vendorObject.purposeConsents['10']).to.be.false;
 	});
 
 	it('selects vendor IDs', () => {
@@ -169,6 +168,7 @@ describe('store', () => {
 
 		store.selectVendor(2, false);
 		store.selectVendor(3, true);
+		store.persist();
 
 		const vendorObject = store.getVendorConsentsObject();
 		const selectedVendorIds = Object.keys(vendorObject.vendorConsents).filter(key => vendorObject.vendorConsents[key]);
@@ -186,6 +186,7 @@ describe('store', () => {
 		});
 
 		store.selectAllVendors(true);
+		store.persist();
 
 		const vendorObject = store.getVendorConsentsObject();
 		const selectedVendorIds = Object.keys(vendorObject.vendorConsents).filter(key => vendorObject.vendorConsents[key]);
@@ -205,9 +206,10 @@ describe('store', () => {
 
 		store.selectPurpose(0, false);
 		store.selectPurpose(4, true);
+		store.persist();
 
 		const vendorObject = store.getVendorConsentsObject();
-		const selectedPurposeIds = Object.keys(vendorObject.purposes).filter(key => vendorObject.purposes[key]);
+		const selectedPurposeIds = Object.keys(vendorObject.purposeConsents).filter(key => vendorObject.purposeConsents[key]);
 
 		expect(selectedPurposeIds).to.deep.equal(['1', '2', '4']);
 	});
@@ -223,9 +225,10 @@ describe('store', () => {
 
 
 		store.selectAllPurposes(true);
+		store.persist();
 
 		const vendorObject = store.getVendorConsentsObject();
-		const selectedPurposeIds = Object.keys(vendorObject.purposes).filter(key => vendorObject.purposes[key]);
+		const selectedPurposeIds = Object.keys(vendorObject.purposeConsents).filter(key => vendorObject.purposeConsents[key]);
 
 		expect(selectedPurposeIds.length).to.equal(vendorList.purposes.length);
 	});
@@ -241,6 +244,7 @@ describe('store', () => {
 
 		store.selectCustomPurpose(0, false);
 		store.selectCustomPurpose(3, true);
+		store.persist();
 
 		const publisherObject = store.getPublisherConsentsObject();
 		const selectedCustomPurposeIds = Object.keys(publisherObject.customPurposes).filter(key => publisherObject.customPurposes[key]);
@@ -258,6 +262,7 @@ describe('store', () => {
 		});
 
 		store.selectAllCustomPurposes(true);
+		store.persist();
 
 		const publisherObject = store.getPublisherConsentsObject();
 		const selectedCustomPurposeIds = Object.keys(publisherObject.customPurposes).filter(key => publisherObject.customPurposes[key]);

--- a/src/lib/vendor.js
+++ b/src/lib/vendor.js
@@ -6,20 +6,12 @@ import { sendPortalCommand } from './portal';
 
 const LOCAL_VENDOR_LIST_LOCATION = `//${window.location.host}/cmp/vendors.json`;
 
+/**
+	* Attempt to load a vendor list from the local domain. If a
+	* list is not found attempt to load it from the global list location
+	* using the "portal" for cross domain communication.
+*/
 function fetchVendorList() {
-	/**
-	 * Global consent triggered should always load all vendors.
-	 */
-	if (config.storeConsentGlobally) {
-		log.debug('Consent to be stored globally. Requesting global list');
-		return sendPortalCommand({command: 'readVendorList'});
-	}
-
-	/**
-	 * Attempt to load a vendor list from the local domain. If a
-	 * list is not found attempt to load it from the global list location
-	 * using the "portal" for cross domain communication.
-	 */
 	return fetch(LOCAL_VENDOR_LIST_LOCATION)
 		.then(res => res.json())
 		.catch(() => {


### PR DESCRIPTION
Fully implements https://github.com/digi-trust/cmp/issues/6

Language is used first, then country is taken from making an external call to a service where we can grab the country from the IP in a header and use that to determine whether or not to show the CMP based on physical location

Also handles https://github.com/digi-trust/cmp/issues/35 , incorporating work already done from the AppNexus implementation into this fork and changing it where necessary.

Closes https://github.com/digi-trust/cmp/issues/30, https://github.com/digi-trust/cmp/issues/1, https://github.com/digi-trust/cmp/issues/39, https://github.com/digi-trust/cmp/issues/42, https://github.com/digi-trust/cmp/issues/16, https://github.com/digi-trust/cmp/issues/15