### PR TITLE
introduce testing mode, fix for rendering logic

### DIFF
--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -1,0 +1,55 @@
+import { h, Component } from 'preact';
+import Label from '../label/label';
+import style from './popover.less';
+
+export default class Popover extends Component {
+  state = {
+    show: false
+  };
+
+  static defaultProps = {
+    content: ''
+  };
+
+  mouseEnter = () => {
+    this.setState({show: true});
+  }
+
+  mouseLeave = () => {
+    this.setState({show: false});
+  }
+
+  handleClick = () => {
+    this.setState({show: !this.state.show});
+  }
+
+  render(props, state) {
+    const {
+      inlineContent,
+      inlineLocalizeKey,
+      popoverContent,
+      popoverLocalizeKey
+    } = props;
+
+    const {
+      show
+    } = state;
+
+    return (
+      <span>
+        <a
+          onClick={this.handleClick}
+          // onMouseEnter={this.mouseEnter}
+          // onMouseLeave={this.mouseLeave}
+        >
+          <Label providedValue={inlineContent} localizeKey={inlineLocalizeKey}>{inlineContent}</Label>
+        </a>
+        {show &&
+          <div class={style.popover}>
+            <Label providedValue={popoverContent} localizeKey={popoverLocalizeKey}>{popoverLocalizeKey}</Label>
+          </div>
+        }
+      </span>
+    );
+  }
+}

--- a/src/components/popover/popover.less
+++ b/src/components/popover/popover.less
@@ -1,0 +1,14 @@
+@import '../../style/variables';
+
+.popover {
+  position: absolute;
+  background-color: white;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);
+  padding: 10px;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  max-width: 90%;
+  max-height: 300px;
+  overflow: scroll;
+}

--- a/src/components/popup/details/details.jsx
+++ b/src/components/popup/details/details.jsx
@@ -125,9 +125,11 @@ export default class Details extends Component {
 				</div>
 				<div class={style.footer}>
 					<div class={style.leftFooter}>
+					{(selectedPanelIndex === SECTION_PURPOSES) &&
 						<a class={style.vendorLink} onClick={this.handleShowVendors}>
 							<LocalLabel providedValue={localization && localization.details ? localization.details.showVendors : ''} localizeKey='showVendors'>Show all companies</LocalLabel>
 						</a>
+					}
 					</div>
 					<div class={style.rightFooter}>
 						<a class={style.cancel} onClick={this.handleBack}>

--- a/src/components/popup/details/details.jsx
+++ b/src/components/popup/details/details.jsx
@@ -17,7 +17,8 @@ class LocalLabel extends Label {
 
 export default class Details extends Component {
 	state = {
-		selectedPanelIndex: SECTION_PURPOSES
+		selectedPanelIndex: SECTION_PURPOSES,
+		showEnableAll: true
 	};
 
 	handleShowVendors = () => {
@@ -33,11 +34,15 @@ export default class Details extends Component {
 	};
 
 	handleEnableAll = () => {
-		const { onSave } = this.props;
-		const { selectAllVendors } = this.props.store;
+		const shouldSelectAll = this.state.showEnableAll;
+		const {
+			selectAllVendors,
+			selectAllPurposes
+		} = this.props.store;
 
-		selectAllVendors(true);
-		onSave();
+		selectAllVendors(shouldSelectAll);
+		selectAllPurposes(shouldSelectAll);
+		this.setState({showEnableAll: !this.state.showEnableAll});
 	};
 
 	handleBack = () => {
@@ -59,7 +64,11 @@ export default class Details extends Component {
 			store,
 			localization
 		} = props;
-		const { selectedPanelIndex } = state;
+
+		const {
+			selectedPanelIndex,
+			showEnableAll
+		} = state;
 
 		const {
 			vendorList = {},
@@ -82,7 +91,12 @@ export default class Details extends Component {
 				<div class={style.header}>
 					<LocalLabel class={style.title} providedValue={localization && localization.details ? localization.details.title : ''} localizeKey='title'>Privacy Preferences</LocalLabel>
 					<Button class={style.save} onClick={this.handleEnableAll}>
+						{state.showEnableAll &&
 						<LocalLabel providedValue={localization && localization.details ? localization.details.enableAll : ''} localizeKey='enableAll'>Enable all</LocalLabel>
+						}
+						{!state.showEnableAll &&
+						<LocalLabel providedValue={localization && localization.details ? localization.details.disableAll : ''} localizeKey='disableAll'>Disable all</LocalLabel>
+						}
 					</Button>
 				</div>
 				<div class={style.body}>

--- a/src/components/popup/details/details.less
+++ b/src/components/popup/details/details.less
@@ -34,7 +34,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		flex: 0 1 80px;
+		flex: 0 1 60px;
 		border-top: 1px solid @color-border;
 	}
 	.leftFooter {

--- a/src/components/popup/details/purposes/purposes.jsx
+++ b/src/components/popup/details/purposes/purposes.jsx
@@ -128,7 +128,12 @@ export default class Purposes extends Component {
 									<LocalLabel localizeKey={`${currentPurposeLocalizePrefix}.title`}>{selectedPurpose.name}</LocalLabel>
 								</div>
 								<div class={style.active}>
-									<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.active : ''} localizeKey='active'>Active</LocalLabel>
+									{purposeIsActive &&
+										<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.active : ''} localizeKey='active'>Active</LocalLabel>
+									}
+									{!purposeIsActive &&
+										<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.inactive : ''} localizeKey='inactive'>Inactive</LocalLabel>
+									}
 									<Switch
 										isSelected={purposeIsActive}
 										onClick={this.handleSelectPurpose}

--- a/src/components/popup/details/purposes/purposes.less
+++ b/src/components/popup/details/purposes/purposes.less
@@ -53,7 +53,6 @@
 
 			.detailHeader {
 				display: flex;
-				flex-wrap: wrap;
 			}
 			.title {
 				font-size: 24px;
@@ -68,7 +67,7 @@
 				color: @color-primary;
 				font-weight: bold;
 				display: flex;
-				align-items: center;
+				padding-top: 6px;
 				@media @smartphone {
 					flex: 1 1 auto;
 				}

--- a/src/components/popup/details/vendors/vendors.jsx
+++ b/src/components/popup/details/vendors/vendors.jsx
@@ -77,7 +77,7 @@ export default class Vendors extends Component {
 						<tbody>
 						{vendors.map(({ id, name, policyUrl, purposeIds, legIntPurposeIds, featureIds }, index) => (
 							<tr key={id} class={index % 2 === 1 ? style.even : ''}>
-								<td><div class={style.vendorName}>{name}</div></td>
+								<td><a href={policyUrl}><div class={style.vendorName}>{name}</div></a></td>
 								<td>
 									<Switch
 										dataId={id}

--- a/src/components/popup/intro/intro.jsx
+++ b/src/components/popup/intro/intro.jsx
@@ -2,6 +2,7 @@ import { h, Component } from 'preact';
 import style from './intro.less';
 import Button from '../../button/button';
 import Label from '../../label/label';
+import Popover from '../../popover/popover';
 
 class LocalLabel extends Label {
 	static defaultProps = {
@@ -31,7 +32,21 @@ export default class Intro extends Component {
 					<LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
 				</div>
 				<div class={style.description}>
-					<LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description'>Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.</LocalLabel>
+					<LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description'>Ads help us run this site. When you use our site selected companies may access and use </LocalLabel>
+					<Popover
+						inlineContent={localization && localization.intro ? localization.intro.deviceInformation : ''}
+						inlineLocalizeKey='intro.deviceInformation'
+						popoverContent={localization && localization.intro ? localization.intro.deviceInformationPopover : ''}
+						popoverLocalizeKey='intro.deviceInformationPopover'
+					/>
+					<LocalLabel providedValue={localization && localization.intro ? localization.intro.description2 : ''} localizeKey='description2'>for various </LocalLabel>
+					<Popover
+						inlineContent={localization && localization.intro ? localization.intro.purposes : ''}
+						inlineLocalizeKey='intro.purposes'
+						popoverContent={localization && localization.intro ? localization.intro.purposesPopover : ''}
+						popoverLocalizeKey='intro.purposesPopover'
+					/>
+					<LocalLabel providedValue={localization && localization.intro ? localization.intro.description3 : ''} localizeKey='description3'> including to serve relevant ads or personalised content.</LocalLabel>
 				</div>
 				<div class={style.options}>
 					<Button

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -150,7 +150,7 @@ export default class Cmp {
 			return fetch(self.config.geoIPVendor)
 				.then(resp => {
 				  let countryISO = resp.headers.get("X-GeoIP-Country");
-				  if (EU_COUNTRY_CODES.has(countryISO.toUpperCase())) {
+				  if (EU_COUNTRY_CODES.has(countryISO)) {
 						self.store.updateIsEU(true);
 						return true;
 				  }
@@ -210,13 +210,11 @@ export default class Cmp {
 					if (config.gdprAppliesGlobally) {
 						// if no cookie, show tool
 						if (needsPublisherCookie || needsGlobalCookie) {
-							log.debug("GDPR applies globally and user needs a cookie");
 							cmp('showConsentTool');
 						}
 						// if cookie present and current, don't show tool
 						// if cookie present and old, show tool
 						else if (self.utils.checkReprompt(config.repromptOptions, vendorConsents, vendors)) {
-							log.debug("GDPR applies globally and user's cookie is old enough to show reprompt window");
 							cmp('showConsentTool');
 						}
 						else {
@@ -224,29 +222,23 @@ export default class Cmp {
 						}
 					}
 					else {
-						self.utils.checkIfGDPRApplies()
-							.then(applies => {
-								if (applies) {
-									// if geolocation in EU, no cookie present, show tool
-									if (needsPublisherCookie || needsGlobalCookie) {
-										log.debug("User is either in the EU or their language is set to an EU code and user needs a cookie");
-										cmp('showConsentTool');
-									} else {
-										log.debug("User is either in the EU or their language is set to an EU code and user's cookie is current");
-										store.toggleFooterShowing(true);
-									}
-								}
-								// if cookie present and current, don't show tool
-								// if cookie present and old, show tool
-								else if (self.utils.checkReprompt(config.repromptOptions, vendorConsents, vendors)) {
-									log.debug("User is either in the EU or their language is set to an EU code and user's cookie is old enough to show reprompt window");
-									cmp('showConsentTool');
-								}
-								else {
-									// if not in EU, no cookie present, don't show tool
-									log.debug("rendering the CMP is not needed");
-								}
-							});
+						// if not in EU, no cookie present, don't show tool
+						// if geolocation in EU, no cookie present, show tool
+						if (self.utils.checkIfGDPRApplies()) {
+							if (needsPublisherCookie || needsGlobalCookie) {
+								cmp('showConsentTool');
+							} else {
+								store.toggleFooterShowing(true);
+							}
+						}
+						// if cookie present and current, don't show tool
+						// if cookie present and old, show tool
+						else if (self.utils.checkReprompt(config.repromptOptions, vendorConsents, vendors)) {
+							cmp('showConsentTool');
+						}
+						else {
+							log.debug("rendering the CMP is not needed");
+						}
 					}
 				});
 				callback();
@@ -267,7 +259,7 @@ export default class Cmp {
 		 * @param {Array} vendorIds Array of vendor IDs to retrieve.  If empty return all vendors.
 		 */
 		getVendorConsents: (vendorIds, callback = () => {}) => {
-			const consent = this.store.getVendorConsentsObject(vendorIds);
+			const consent = this.store.getVendorConsentsObject(vendorIds)
 			callback(consent);
 			return consent;
 		},

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -203,16 +203,6 @@ export default class Cmp {
 					cmp('getVendorConsents'),
 					cmp('getVendorList')
 				]).then(([{vendorConsents}, {vendors}]) => {
-					if (config.testingMode === 'always show') {
-						log.debug("Testing mode set to ALWAYS SHOW; rendering the CMP");
-						cmp('showConsentTool');
-						return;
-					} else if (config.testingMode === 'never show') {
-						log.debug("Testing mode set to NEVER SHOW; not rendering the CMP");
-						return;
-					}
-					log.debug("Testing mode set to NORMAL; checking to see if CMP needs to be rendered...");
-
 					let needsPublisherCookie = false;
 					if (config.storePublisherData && !store.getPublisherConsentsObject().lastUpdated) needsPublisherCookie = true;
 					let needsGlobalCookie = false;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -15,6 +15,7 @@ const defaultConfig = {
 		noConsentGiven: 30,
 	},
 	geoIPVendor: 'http://cmp.digitru.st/geoip.json',
+	testingMode: 'normal'
 };
 
 class Config {

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -6,7 +6,6 @@ import {
 import config from './config';
 import {
 	updateLocalizationSettings,
-	currentLocale
 } from './localize';
 const metadata = require('../../metadata.json');
 

--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -9,7 +9,33 @@ export default {
 		intro: {
 			title: 'Thanks for visiting ',
 			domain: '',
-			description: 'Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.',
+			description: 'Ads help us run this site. When you use our site selected companies may access and use ',
+			description2: ' for various ',
+			description3: ' including to serve relevant ads or personalised content.',
+			deviceInformation: 'information on your device',
+			deviceInformationPopover: `
+				<strong>Information that may be used:</strong>
+				<ul>
+					<li>Type of browser and its settings</li>
+					<li>Information about the device's operating system</li>
+					<li>Cookie information</li>
+					<li>Information about other identifiers assigned to the device</li>
+					<li>The IP address from which the device accesses a client's website or mobile application</li>
+					<li>Information about the user's activity on that device, including web pages and mobile apps visited or used</li>
+					<li>Information about the geographic location of the device when it accesses a website or mobile application</li>
+				</ul>
+			`,
+			purposes: 'purposes',
+			purposesPopover: `
+				<strong>Purposes for storing information:</strong>
+				<ul>
+					<li>Storage and access of information</li>
+					<li>Ad selection and delivery</li>
+					<li>Content selection and delivery</li>
+					<li>Personalization</li>
+					<li>Measurement</li>
+				</ul>
+			`,
 			acceptAll: 'OK, Continue to site',
 			rejectAll: '',
 			showPurposes: 'Learn more'

--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -19,10 +19,12 @@ export default {
 			cancel: 'Back',
 			save: 'OK, Continue to site',
 			showVendors: 'Show all companies',
-			enableAll: 'Enable all'
+			enableAll: 'Enable all',
+			disableAll: 'Disable all'
 		},
 		purposes: {
-			active: '',
+			active: 'Active',
+			inactive: 'Inactive',
 			disclaimer: 'We and selected companies may access and use information for the purposes outlined. You may customise your choice or continue using our site if you are OK with the purposes. You can see the ',
 			disclaimerVendorLink: 'complete list of companies here.',
 			showVendors: 'Show companies',


### PR DESCRIPTION
Fixes https://github.com/digi-trust/cmp/issues/54, closes https://github.com/digi-trust/cmp/issues/56, https://github.com/digi-trust/cmp/issues/51

@hbruce27 @anissaconnor , possible options for this testing mode are `normal`, `always show`, and `never show`. If "never show" is active, then the only way for the CMP to render is with that Javascript command pasted into the terminal ( `window.__cmp('showConsentTool')` ) or if the publisher puts a button on their page with that command as the onclick event.