### PR TITLE
add translation file keys

### DIFF
--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -41,9 +41,9 @@ export default class Footer extends Component {
 					class={style.close}
 					onClick={this.handleClose}
 				/>
-				<LocalLabel providedValue={localization && localization.footer ? localization.footer.message : ''} localizeKey='message' class={style.message}>A reminder you can control your user privacy preferences</LocalLabel>
+				<LocalLabel providedValue={localization && localization.footer ? localization.footer.closedMessage : ''} localizeKey='closedMessage' class={style.message}>A reminder you can control your user privacy preferences</LocalLabel>
 				<a class={style.openConsent} onClick={this.handleShowConsent}>
-					<LocalLabel providedValue={localization && localization.footer ? localization.footer.consentLink : ''} localizeKey='consentLink'>here</LocalLabel>
+					<LocalLabel providedValue={localization && localization.footer ? localization.footer.closedMessageLink : ''} localizeKey='closedMessageLink'>here</LocalLabel>
 				</a>
 			</div>
 		);

--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -66,6 +66,8 @@ export default {
 		},
 		footer: {
 			message: 'Read more about access and use of information on your device for various purposes',
+			closedMessage: 'A reminder you can control your user privacy preferences ',
+			closedMessageLink: 'here',
 			deviceInformationHeader: 'Information that may be used:',
 			deviceInformation: `
 				<ul>
@@ -151,6 +153,8 @@ export default {
 		},
 		footer: {
 			message: '',
+			closedMessage: '',
+			closedMessageLink: '',
 			deviceInformationHeader: 'Información que puede ser utilizada:',
 			deviceInformation: `
 				<ul>
@@ -236,6 +240,8 @@ export default {
 		},
 		footer: {
 			message: '',
+			closedMessage: '',
+			closedMessageLink: '',
 			deviceInformationHeader: 'Informationen, die verwendet werden können:',
 			deviceInformation: `
 				<ul>
@@ -321,6 +327,8 @@ export default {
 		},
 		footer: {
 			message: '',
+			closedMessage: '',
+			closedMessageLink: '',
 			deviceInformationHeader: 'Informacja, którą można wykorzystać:',
 			deviceInformation: `
 				<ul>
@@ -406,6 +414,8 @@ export default {
 		},
 		footer: {
 			message: '',
+			closedMessage: '',
+			closedMessageLink: '',
 			deviceInformationHeader: 'Informacija, kuri gali būti naudojama:',
 			deviceInformation: `
 				<ul>
@@ -491,6 +501,8 @@ export default {
 		},
 		footer: {
 			message: '',
+			closedMessage: '',
+			closedMessageLink: '',
 			deviceInformationHeader: 'Informazioni che potranno essere utilizzate:',
 			deviceInformation: `
 				<ul>
@@ -576,6 +588,8 @@ export default {
 		},
 		footer: {
 			message: '',
+			closedMessage: '',
+			closedMessageLink: '',
 			deviceInformationHeader: 'Peuvent être utilisées:',
 			deviceInformation: `
 				<ul>


### PR DESCRIPTION
We need translations for two additional strings:


<img width="1416" alt="screen shot 2018-05-24 at 7 56 46 am" src="https://user-images.githubusercontent.com/4782746/40493927-832be662-5f28-11e8-89e6-4e4387169f86.png">


<img width="1440" alt="screen shot 2018-05-24 at 7 57 01 am" src="https://user-images.githubusercontent.com/4782746/40493936-85cce3da-5f28-11e8-8b7a-2f08808e3355.png">
