### PR TITLE
stub __cmp.commandQueue in basicInclude

### DIFF
--- a/src/docs/components/docs/quickstart.jsx
+++ b/src/docs/components/docs/quickstart.jsx
@@ -11,6 +11,19 @@ const SCRIPT_PATH = Url.resolve(`//${host}${pathname}`, '../cmp.complete.bundle.
 const basicInclude = `
 <html>
 	<body>
+		<script>
+			var commandQueue = [];
+			var cmp = function(command, parameter, callback) {
+				commandQueue.push({
+					command: command,
+					parameter: parameter,
+					callback: callback
+				});
+			};
+			cmp.commandQueue = commandQueue;
+			cmp.config = {};
+			window.__cmp = cmp;
+		</script>
 		<script src="${SCRIPT_PATH}" async></script>
 	</body>
 </html>


### PR DESCRIPTION
The `__cmp` API is unusable without this stub included before the `cmp.complete.bundle.js` script.