### PR TITLE
add 'cmp=true' to every element in the CMP 

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -13,52 +13,52 @@ export default class App extends Component {
 
 	elementsWithReplaceableCss = {
 		// Tables
-		"thead tr": {"background-color": this.props.config.css["color-table-background"]},
-		"tr[class*=even]": {"background-color": this.props.config.css["color-table-background"]},
+		"[cmp=true] thead tr": {"background-color": this.props.config.css["color-table-background"]},
+		"[cmp=true] tr[class*=even]": {"background-color": this.props.config.css["color-table-background"]},
 
 		// Purposes
-		"div[class*=purposes_purposeItem]": {
+		"[cmp=true] div[class*=purposes_purposeItem]": {
 			"background-color": this.props.config.css["color-secondary"],
 			"color": this.props.config.css["color-text-secondary"]
 		},
-		"div[class*=selectedPurpose]": {
+		"[cmp=true] div[class*=selectedPurpose]": {
 			"background-color": this.props.config.css["color-primary"],
 			"color": this.props.config.css["color-text-secondary"],
 		},
 
 		// Footer
-		"div[class*=footer_footer]": {
+		"[cmp=true] div[class*=footer_footer]": {
 			"border-top": "3px solid " + this.props.config.css["color-border"],
 			"background-color": this.props.config.css["color-background"]
 		},
-		"div[class*=footerV2_extended]": {"border-top": "3px solid " + this.props.config.css["color-border"]},
-		"div[class*=footerV2_container]": {"background-color": this.props.config.css["color-background"]},
-		"svg": {
+		"[cmp=true] div[class*=footerV2_extended]": {"border-top": "3px solid " + this.props.config.css["color-border"]},
+		"[cmp=true] div[class*=footerV2_container]": {"background-color": this.props.config.css["color-background"]},
+		"[cmp=true] svg": {
 			"background-color": this.props.config.css["color-background"],
 			"fill": this.props.config.css["color-primary"]
 		},
 
 		// Vendors
-		"[class*=active]": {"color": this.props.config.css["color-primary"]},
+		"[cmp=true] [class*=active]": {"color": this.props.config.css["color-primary"]},
 
 		// Application wide
-		"div[name^=content]": {
+		"[cmp=true] div[name^=content]": {
 			"box-shadow": "0 0 0 3px " + this.props.config.css["color-border"],
 			"background-color": this.props.config.css["color-background"]
 		},
-		":not([name*=ctrl])": {
+		"[cmp=true] :not([name*=ctrl])": {
 			"font-family": this.props.config.css["font-family"]
 		},
-		"[class*=primaryText]": {"color": this.props.config.css["color-text-primary"]},
-		"[class*=secondaryText]": {"color": this.props.config.css["color-text-secondary"]},
-		"a": {"color": this.props.config.css["color-linkColor"]},
-		"span[class*=isSelected] [class*=visualizationGlow]": {"background-color": this.props.config.css["color-primary"]},
-		"span[class*=isSelected] [class*=visualizationContainer]": {"background-color": this.props.config.css["color-primary"]},
-		"[class*=button]": {
+		"[cmp=true] [class*=primaryText]": {"color": this.props.config.css["color-text-primary"]},
+		"[cmp=true] [class*=secondaryText]": {"color": this.props.config.css["color-text-secondary"]},
+		"[cmp=true] a": {"color": this.props.config.css["color-linkColor"]},
+		"[cmp=true] span[class*=isSelected] [class*=visualizationGlow]": {"background-color": this.props.config.css["color-primary"]},
+		"[cmp=true] span[class*=isSelected] [class*=visualizationContainer]": {"background-color": this.props.config.css["color-primary"]},
+		"[cmp=true] [class*=button]": {
 			"color": this.props.config.css["color-background"],
 			"background-color": this.props.config.css["color-primary"],
 		},
-		"[class*=button_invert]": {
+		"[cmp=true] [class*=button_invert]": {
 			"color": this.props.config.css["color-primary"],
 			"border": "2px solid " + this.props.config.css["color-primary"],
 			"background-color": this.props.config.css["color-background"]
@@ -118,7 +118,7 @@ export default class App extends Component {
 		const userLocalization = config.localization[currentLocale];
 
 		return (
-			<div class={style.gdpr}>
+			<div cmp={true} class={style.gdpr}>
 				<Popup
 					store={store}
 					localization={userLocalization}

--- a/src/components/app.test.js
+++ b/src/components/app.test.js
@@ -84,7 +84,6 @@ describe('App', () => {
 		/>, scratch);
 
 		expect(app.props.config.css['font-family']).to.equal('MonoType');
-		expect(scratch.style['font-family']).to.equal('MonoType');
 		expect(scratch.innerHTML).to.contain('style="font-family: MonoType;"');
 	});
 });

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -18,6 +18,7 @@ export default class Button extends Component {
 
 		return (
 			<button
+				cmp={true}
 				class={[style.button, props.class, invert ? style.invert : ''].join(' ')}
 				onClick={onClick}>
 				{children}

--- a/src/components/closebutton/closebutton.jsx
+++ b/src/components/closebutton/closebutton.jsx
@@ -24,9 +24,10 @@ export default class CloseButton extends Component {
 
 		return (
 			<span
+				cmp={true}
 				class={[style.closeButton, hasBorder ? style.hasBorder : '', props.class].join(' ')}
 				onClick={onClick}>
-				<svg width={width} height={height} viewBox='0 0 16 16' preserveAspectRatio='xMidYMid meet'>
+				<svg cmp={true} width={width} height={height} viewBox='0 0 16 16' preserveAspectRatio='xMidYMid meet'>
 					<path d='M6.837 8l-2.45-2.464 1.17-1.17 2.45 2.464 2.465-2.465 1.17 1.17L9.162 8l2.48 2.464-1.167 1.17-2.467-2.48-2.48 2.48-1.17-1.17L6.838 8z'></path>
 				</svg>
 			</span>

--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -37,6 +37,7 @@ export default class Footer extends Component {
 
 		return (
 			<div
+				cmp={true}
 				class={style.footer}
 				style={{ display: isFooterShowing && config.showFooterAfterSubmit ? 'flex' : 'none' }}
 				>
@@ -48,7 +49,7 @@ export default class Footer extends Component {
 					updateCSSPrefs={updateCSSPrefs}
 				/>
 				<LocalLabel providedValue={localization && localization.footer ? localization.footer.closedMessage : ''} localizeKey='closedMessage' class={style.message + " primaryText"}>A reminder you can control your user privacy preferences</LocalLabel>
-				<a class={style.openConsent} onClick={this.handleShowConsent}>
+				<a cmp={true} class={style.openConsent} onClick={this.handleShowConsent}>
 					<LocalLabel providedValue={localization && localization.footer ? localization.footer.closedMessageLink : ''} localizeKey='closedMessageLink'>here</LocalLabel>
 				</a>
 			</div>

--- a/src/components/label/label.jsx
+++ b/src/components/label/label.jsx
@@ -13,6 +13,7 @@ export default class Label extends Component {
 
 		return (
 			<span
+				cmp={true}
 				class={props.class || className}
 				dangerouslySetInnerHTML={localizedContent && {__html: localizedContent}}>
 				{!localizedContent && children}

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -38,6 +38,7 @@ export default class Popover extends Component {
     return (
       <span>
         <a
+          cmp={true}
           onClick={this.handleClick}
           // onMouseEnter={this.mouseEnter}
           // onMouseLeave={this.mouseLeave}
@@ -45,7 +46,7 @@ export default class Popover extends Component {
           <Label providedValue={inlineContent} localizeKey={inlineLocalizeKey}>{inlineContent}</Label>
         </a>
         {show &&
-          <div class={style.popover}>
+          <div cmp={true} class={style.popover}>
             <Label providedValue={popoverContent} localizeKey={popoverLocalizeKey}>{popoverLocalizeKey}</Label>
           </div>
         }

--- a/src/components/popup/details/details.jsx
+++ b/src/components/popup/details/details.jsx
@@ -93,11 +93,11 @@ export default class Details extends Component {
 
 
 		return (
-			<div class={style.details}>
-				<div class={style.header}>
+			<div cmp={true} class={style.details}>
+				<div cmp={true} class={style.header}>
 					<LocalLabel class={style.title + " primaryText"} providedValue={localization && localization.details ? localization.details.title : ''} localizeKey='title'>Privacy Preferences</LocalLabel>
 				</div>
-				<div class={style.body}>
+				<div cmp={true} class={style.body}>
 					<Panel selectedIndex={selectedPanelIndex}>
 						<Purposes
 							localization={localization}
@@ -126,19 +126,19 @@ export default class Details extends Component {
 						/>
 					</Panel>
 				</div>
-				<div class={style.footer}>
-					<div class={style.leftFooter}>
+				<div cmp={true} class={style.footer}>
+					<div cmp={true} class={style.leftFooter}>
 					{(selectedPanelIndex === SECTION_PURPOSES) &&
-						<a class={style.vendorLink} onClick={this.handleShowVendors}>
+						<a cmp={true} class={style.vendorLink} onClick={this.handleShowVendors}>
 							<LocalLabel providedValue={localization && localization.details ? localization.details.showVendors : ''} localizeKey='showVendors'>Show all companies</LocalLabel>
 						</a>
 					}
 					</div>
-					<div class={style.rightFooter}>
-						<a class={style.cancel} onClick={this.handleBack}>
+					<div cmp={true} class={style.rightFooter}>
+						<a cmp={true} class={style.cancel} onClick={this.handleBack}>
 							<LocalLabel providedValue={localization && localization.details ? localization.details.back : ''} localizeKey='back'>Back</LocalLabel>
 						</a>
-						<Button class={style.save} onClick={onSave}>
+						<Button cmp={true} class={style.save} onClick={onSave}>
 							<LocalLabel providedValue={localization && localization.details ? localization.details.save : ''} localizeKey='save'>OK, Continue to site</LocalLabel>
 						</Button>
 					</div>

--- a/src/components/popup/details/purposes/purposes.jsx
+++ b/src/components/popup/details/purposes/purposes.jsx
@@ -114,17 +114,17 @@ export default class Purposes extends Component {
 		const currentPurposeLocalizePrefix = `${selectedPurposeIndex >= purposes.length ? 'customPurpose' : 'purpose'}${selectedPurposeId}`;
 
 		return (
-			<div class={style.container} >
-				<div class={style.disclaimer + " primaryText"}>
+			<div cmp={true} class={style.container} >
+				<div cmp={true} class={style.disclaimer + " primaryText"}>
 					<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.disclaimer : ''} localizeKey='disclaimer'>We and selected companies may access and use information for the purposes outlined. You may customise your choice or continue using our site if you are OK with the purposes. You can see the </LocalLabel>
-					<a class={style.vendorLink} onClick={onShowVendors}>
+					<a cmp={true} class={style.vendorLink} onClick={onShowVendors}>
 						<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.disclaimerVendorLink : ''} localizeKey='disclaimerVendorLink'>complete list of companies here.</LocalLabel>
 					</a>
 				</div>
-				<div class={style.purposes}>
-					<div class={style.purposeList}>
+				<div cmp={true} class={style.purposes}>
+					<div cmp={true} class={style.purposeList}>
 						{allPurposes.map((purpose, index) => (
-							<div class={[style.purposeItem, selectedPurposeIndex === index ? style.selectedPurpose : ''].join(' ')}
+							<div cmp={true} class={[style.purposeItem, selectedPurposeIndex === index ? style.selectedPurpose : ''].join(' ')}
 								 onClick={this.handleSelectPurposeDetail(index)}
 							>
 								<LocalLabel localizeKey={`${index >= purposes.length ? 'customPurpose' : 'purpose'}${purpose.id}.menu`}>{purpose.name}</LocalLabel>
@@ -132,24 +132,24 @@ export default class Purposes extends Component {
 						))}
 					</div>
 					{selectedPurpose &&
-					<div class={style.purposeDescription} ref={scrollRef => this.scrollRef = scrollRef}>
-						<div class={style.purposeDetail + " primaryText"}>
-							<div class={style.detailHeader}>
-								<div class={style.title}>
+					<div cmp={true} class={style.purposeDescription} ref={scrollRef => this.scrollRef = scrollRef}>
+						<div cmp={true} class={style.purposeDetail + " primaryText"}>
+							<div cmp={true} class={style.detailHeader}>
+								<div cmp={true} class={style.title}>
 									<LocalLabel localizeKey={`${currentPurposeLocalizePrefix}.title`}>{selectedPurpose.name}</LocalLabel>
 								</div>
 							</div>
 
-							<div class={style.body}>
-								<p><LocalLabel providedValue={selectedPurpose.description} localizeKey={`${currentPurposeLocalizePrefix}.description`} /></p>
-								<p><LocalLabel providedValue={localization && localization.purposes ? localization.purposes.featureHeader : ''} localizeKey='featureHeader'>This will include the following features:</LocalLabel></p>
-								<ul>
+							<div cmp={true} class={style.body}>
+								<p cmp={true}><LocalLabel providedValue={selectedPurpose.description} localizeKey={`${currentPurposeLocalizePrefix}.description`} /></p>
+								<p cmp={true}><LocalLabel providedValue={localization && localization.purposes ? localization.purposes.featureHeader : ''} localizeKey='featureHeader'>This will include the following features:</LocalLabel></p>
+								<ul cmp={true}>
 								{features.map((feature, index) => (
-									<li><LocalLabel class='featureItem' providedValue={feature.description} /></li>
+									<li cmp={true}><LocalLabel class='featureItem' providedValue={feature.description} /></li>
 								))}
 								</ul>
-								<div class={style.switchWrap}>
-									<div class={style.active}>
+								<div cmp={true} class={style.switchWrap}>
+									<div cmp={true} class={style.active}>
 										<Switch
 											isSelected={purposeIsActive}
 											onClick={this.handleSelectPurpose}
@@ -161,37 +161,37 @@ export default class Purposes extends Component {
 											<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.inactive : ''} localizeKey='inactive'>Inactive</LocalLabel>
 										}
 									</div>
-									<span class={style.switchText}>
+									<span cmp={true} class={style.switchText}>
 										<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.switchText : ''} localizeKey="switchText">Publisher and their partners could collect anonymized information in order to improve your experience on our site.</LocalLabel>
 									</span>
 								</div>
 								{!showLocalVendors &&
-								<a class={style.vendorLink} onClick={this.onShowLocalVendors}>
+								<a cmp={true} class={style.vendorLink} onClick={this.onShowLocalVendors}>
 									<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.showVendors : ''} localizeKey='showVendors'>Show companies</LocalLabel>
 								</a>
 								}
 								{showLocalVendors &&
-								<a class={style.vendorLink} onClick={this.onHideLocalVendors}>
+								<a cmp={true} class={style.vendorLink} onClick={this.onHideLocalVendors}>
 									<LocalLabel providedValue={localization && localization.purposes ? localization.purposes.hideVendors : ''} localizeKey='hideVendors'>Hide companies</LocalLabel>
 								</a>
 								}
 								{showLocalVendors &&
-									(<div>
-										<div class={style.vendorHeader}>
-											<table class={style.vendorList}>
-												<thead>
-												<tr>
-													<th><LocalLabel providedValue={localization && localization.purposes ? localization.purposes.company : ''} localizeKey='company'>Company</LocalLabel></th>
+									(<div cmp={true}>
+										<div cmp={true} class={style.vendorHeader}>
+											<table cmp={true} class={style.vendorList}>
+												<thead cmp={true}>
+												<tr cmp={true}>
+													<th cmp={true}><LocalLabel providedValue={localization && localization.purposes ? localization.purposes.company : ''} localizeKey='company'>Company</LocalLabel></th>
 												</tr>
 												</thead>
 											</table>
 										</div>
-										<div class={style.vendorContent}>
-											<table class={style.vendorList}>
-												<tbody>
+										<div cmp={true} class={style.vendorContent}>
+											<table cmp={true} class={style.vendorList}>
+												<tbody cmp={true}>
 												{localVendors.map(({name, policyUrl}, index) => (
-													<tr key={index + name} class={index % 2 === 1 ? style.even : ''}>
-														<td><a href={policyUrl} target='_blank'><div class={style.vendorName}>{name}</div></a></td>
+													<tr cmp={true} key={index + name} class={index % 2 === 1 ? style.even : ''}>
+														<td cmp={true}><a cmp={true} href={policyUrl} target='_blank'><div class={style.vendorName}>{name}</div></a></td>
 													</tr>
 												))}
 												</tbody>

--- a/src/components/popup/details/vendors/vendors.jsx
+++ b/src/components/popup/details/vendors/vendors.jsx
@@ -57,45 +57,45 @@ export default class Vendors extends Component {
 		} = props;
 
 		return (
-			<div class={style.vendors}>
-				<div class={style.description + " primaryText"}>
-					<p>
+			<div cmp={true} class={style.vendors}>
+				<div cmp={true} class={style.description + " primaryText"}>
+					<p cmp={true}>
 						<LocalLabel providedValue={localization && localization.vendors ? localization.vendors.description : ''} localizeKey='description'>Companies carefully selected by us will use your information. Depending on the type of data they collect, use, process and other factors, certain companies rely on your consent while others require you to opt-out. For information on each partner and to exercise your choices, see below. Or to opt-out, visit the </LocalLabel>
-						<a href='http://optout.networkadvertising.org/?c=1#!/' target='_blank'>NAI,</a><a href='http://optout.aboutads.info/?c=2#!/' target='_blank'> DAA, </a>
+						<a cmp={true} href='http://optout.networkadvertising.org/?c=1#!/' target='_blank'>NAI,</a><a href='http://optout.aboutads.info/?c=2#!/' target='_blank'> DAA, </a>
 						<LocalLabel providedValue={localization && localization.vendors ? localization.vendors.or : ''} localizeKey='or'>or </LocalLabel>
-						<a href='http://youronlinechoices.eu/' target='_blank'>EDAA</a>
+						<a cmp={true} href='http://youronlinechoices.eu/' target='_blank'>EDAA</a>
 						<LocalLabel providedValue={localization && localization.vendors ? localization.vendors.sites : ''} localizeKey='sites'> sites.</LocalLabel>
 					</p>
-					<p>
+					<p cmp={true}>
 						<LocalLabel providedValue={localization && localization.vendors ? localization.vendors.description2 : ''} localizeKey="description2">Customise how these companies use data on the </LocalLabel>
-						<a style={style.vendorLink} onClick={onShowPurposes}>
+						<a cmp={true} style={style.vendorLink} onClick={onShowPurposes}>
 							<LocalLabel providedValue={localization && localization.vendors ? localization.vendors.description2Link : ''} localizeKey="description2Link">previous page.</LocalLabel>
 						</a>
 					</p>
-					<p>
+					<p cmp={true}>
 					<LocalLabel providedValue={localization && localization.vendors ? localization.vendors.description3 : ''} localizeKey="description3">You can control your preferences for all companies by </LocalLabel>
-						<a style={style.vendorLink} onClick={onHandleEnableAll}>
+						<a cmp={true} style={style.vendorLink} onClick={onHandleEnableAll}>
 							<LocalLabel providedValue={localization && localization.vendors ? localization.vendors.description3Link : ''} localizeKey="description3Link">clicking here.</LocalLabel>
 						</a>
 					</p>
 				</div>
-				<div class={style.vendorHeader}>
-					<table class={style.vendorList}>
-						<thead>
-						<tr>
-							<th class="primaryText"><LocalLabel providedValue={localization && localization.vendors ? localization.vendors.company : ''} localizeKey='company'>Company</LocalLabel></th>
-							<th class="primaryText"><LocalLabel providedValue={localization && localization.vendors ? localization.vendors.offOn : ''} localizeKey='offOn'>Allow</LocalLabel></th>
+				<div cmp={true} class={style.vendorHeader}>
+					<table cmp={true} class={style.vendorList}>
+						<thead cmp={true}>
+						<tr cmp={true}>
+							<th cmp={true} class="primaryText"><LocalLabel providedValue={localization && localization.vendors ? localization.vendors.company : ''} localizeKey='company'>Company</LocalLabel></th>
+							<th cmp={true} class="primaryText"><LocalLabel providedValue={localization && localization.vendors ? localization.vendors.offOn : ''} localizeKey='offOn'>Allow</LocalLabel></th>
 						</tr>
 						</thead>
 					</table>
 				</div>
-				<div class={style.vendorContent}>
-					<table class={style.vendorList}>
-						<tbody>
+				<div cmp={true} class={style.vendorContent}>
+					<table cmp={true} class={style.vendorList}>
+						<tbody cmp={true}>
 						{vendors.map(({ id, name, policyUrl, purposeIds, legIntPurposeIds, featureIds }, index) => (
-							<tr key={id} class={index % 2 === 1 ? style.even : ''}>
-								<td><a href={policyUrl} target='_blank'><div class={style.vendorName}>{name}</div></a></td>
-								<td>
+							<tr cmp={true} key={id} class={index % 2 === 1 ? style.even : ''}>
+								<td cmp={true}><a cmp={true} href={policyUrl} target='_blank'><div class={style.vendorName}>{name}</div></a></td>
+								<td cmp={true}>
 									<Switch
 										dataId={id}
 										isSelected={selectedVendorIds.has(id)}

--- a/src/components/popup/intro/footer.jsx
+++ b/src/components/popup/intro/footer.jsx
@@ -37,41 +37,42 @@ export default class IntroFooter extends Component {
         } = props;
 
         return (
-            <div>
+            <div cmp={true}>
                 {!showFull &&
-                    <div class={style.base + " " + style.collapsed} >
-                        <span name="ctrl" class={style.icon} onClick={this.handleShow}></span>
+                    <div cmp={true} class={style.base + " " + style.collapsed} >
+                        <span cmp={true} name="ctrl" class={style.icon} onClick={this.handleShow}></span>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.message : ''} localizeKey='footer.message' class={style.message + " primaryText"}>Read more about access and use of information on your device for various purposes.</LocalLabel>
                     </div>}
-                {showFull && <div class={style.container}>
-                    <div class={style.base + " " + style.extended}>
-                        <span name="ctrl" class={style.iconDown} onClick={this.handleShow}></span>
+                {showFull && <div cmp={true} class={style.container}>
+                    <div cmp={true} class={style.base + " " + style.extended}>
+                        <span cmp={true} name="ctrl" class={style.iconDown} onClick={this.handleShow}></span>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformationHeader : ''} localizeKey='footer.deviceInformationHeader' class={style.headerMessage + " primaryText"}>Information that may be used</LocalLabel>
                     </div>
 
-                    <div class={style.content}>
+                    <div cmp={true} class={style.content}>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformationHeader : ''} localizeKey='footer.deviceInformationHeader' class={style.message2 + " primaryText"}>Information that may be used:</LocalLabel>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformation : ''} localizeKey='footer.deviceInformation' class={style.message + " primaryText"}>
-                            <ul>
-                                <li>Type of browser and its settings</li>
-                                <li>Information about the device's operating system</li>
-                                <li>Cookie information</li>
-                                <li>Information about other identifiers assigned to the device</li>
-                                <li>The IP address from which the device accesses a client's website or mobile application</li>
-                                <li>Information about the user's activity on that device, including web pages and mobile apps visited or used</li>
-                                <li>Information about the geographic location of the device when it accesses a website or mobile application</li>
+                            <ul cmp={true}>
+                                <li cmp={true}>Type of browser and its settings</li>
+                                <li cmp={true}>Information about the device's operating system</li>
+                                <li cmp={true}>Cookie information</li>
+                                <li cmp={true}>Information about other identifiers assigned to the device</li>
+                                <li cmp={true}>The IP address from which the device accesses a client's website or mobile application</li>
+                                <li cmp={true}>Information about the user's activity on that device, including web pages and mobile apps visited or used</li>
+                                <li cmp={true}>Information about the geographic location of the device when it accesses a website or mobile application</li>
                             </ul>
                         </LocalLabel>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.purposesHeader : ''} localizeKey='footer.purposesHeader' class={style.message2 + " primaryText"}>Purposes for storing information:</LocalLabel>
-                        <ul>
+                        <ul cmp={true}>
                             {store && store.vendorList && store.vendorList.purposes && store.vendorList.purposes.map((purpose) => {
                                 return <li class="primaryText">{purpose.name}</li>
                             })}
                         </ul>
                     </div>
 
-                    <div class={style.infoFooter}>
+                    <div cmp={true} class={style.infoFooter}>
                         <Button
+                            cmp={true}
                             class={style.rejectAll}
                             invert={true}
                             onClick={onShowPurposes}
@@ -79,6 +80,7 @@ export default class IntroFooter extends Component {
                             <LocalLabel providedValue={localization && localization.intro ? localization.intro.showPurposes : ''} localizeKey='intro.showPurposes'>Learn more</LocalLabel>
                         </Button>
                         <Button
+                            cmp={true}
                             class={style.acceptAll}
                             onClick={onAcceptAll}
                         >

--- a/src/components/popup/intro/footerV2.jsx
+++ b/src/components/popup/intro/footerV2.jsx
@@ -37,41 +37,42 @@ export default class IntroFooterV2 extends Component {
         } = props;
 
         return (
-            <div class={style.footerV2}>
+            <div cmp={true} class={style.footerV2}>
                 {!showFull &&
-                    <div class={style.base + " " + style.collapsed}>
-                        <span name="ctrl" class={style.icon} onClick={this.handleShow}></span>
+                    <div cmp={true} class={style.base + " " + style.collapsed}>
+                        <span cmp={true} name="ctrl" class={style.icon} onClick={this.handleShow}></span>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.message : ''} localizeKey='footer.message' class={style.message + " primaryText"}>Read more about access and use of information on your device for various purposes.</LocalLabel>
                     </div>}
-                {showFull && <div class={style.container}>
-                    <div class={style.base + " " + style.extended}>
-                        <span name="ctrl" class={style.iconDown} onClick={this.handleShow}></span>
+                {showFull && <div cmp={true} class={style.container}>
+                    <div cmp={true} class={style.base + " " + style.extended}>
+                        <span cmp={true} name="ctrl" class={style.iconDown} onClick={this.handleShow}></span>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformationHeader : ''} localizeKey='footer.deviceInformationHeader' class={style.headerMessage + " primaryText"}>Information that may be used</LocalLabel>
                     </div>
 
-                    <div class={style.content}>
+                    <div cmp={true} class={style.content}>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformationHeader : ''} localizeKey='footer.deviceInformationHeader' class={style.message2 + " primaryText"}>Information that may be used:</LocalLabel>
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformation : ''} localizeKey='footer.deviceInformation' class={style.message + " primaryText"}>
-                            <ul>
-                                <li>Type of browser and its settings</li>
-                                <li>Information about the device's operating system</li>
-                                <li>Cookie information</li>
-                                <li>Information about other identifiers assigned to the device</li>
-                                <li>The IP address from which the device accesses a client's website or mobile application</li>
-                                <li>Information about the user's activity on that device, including web pages and mobile apps visited or used</li>
-                                <li>Information about the geographic location of the device when it accesses a website or mobile application</li>
+                            <ul cmp={true}>
+                                <li cmp={true}>Type of browser and its settings</li>
+                                <li cmp={true}>Information about the device's operating system</li>
+                                <li cmp={true}>Cookie information</li>
+                                <li cmp={true}>Information about other identifiers assigned to the device</li>
+                                <li cmp={true}>The IP address from which the device accesses a client's website or mobile application</li>
+                                <li cmp={true}>Information about the user's activity on that device, including web pages and mobile apps visited or used</li>
+                                <li cmp={true}>Information about the geographic location of the device when it accesses a website or mobile application</li>
                             </ul>
                         </LocalLabel>
 
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.purposesHeader : ''} localizeKey='footer.purposesHeader' class={style.message2 + " primaryText"}>Purposes for storing information:</LocalLabel>
-                        <ul>
+                        <ul cmp={true}>
                             {store && store.vendorList && store.vendorList.purposes && store.vendorList.purposes.map((purpose) => {
                                 return <li class="primaryText">{purpose.name}</li>
                             })}
                         </ul>
                     </div>
-                    <div class={style.infoFooter}>
+                    <div cmp={true} class={style.infoFooter}>
                             <Button
+                                cmp={true}
                                 class={style.rejectAll}
                                 invert={true}
                                 onClick={onShowPurposes}
@@ -79,6 +80,7 @@ export default class IntroFooterV2 extends Component {
                                 <LocalLabel providedValue={localization && localization.intro ? localization.intro.showPurposes : ''} localizeKey='intro.showPurposes'>Learn more</LocalLabel>
                             </Button>
                             <Button
+                                cmp={true}
                                 class={style.acceptAll}
                                 onClick={onAcceptAll}
                             >

--- a/src/components/popup/intro/intro.jsx
+++ b/src/components/popup/intro/intro.jsx
@@ -32,16 +32,17 @@ export default class Intro extends Component {
 		} = props;
 
 		return (
-			<div class={style.intro}>
-				<div class={style.title + " primaryText"}>
+			<div cmp={true} class={style.intro}>
+				<div cmp={true} class={style.title + " primaryText"}>
 					<LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
 					<LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
 				</div>
-				<div class={style.description + " primaryText"}>
+				<div cmp={true} class={style.description + " primaryText"}>
 					<LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description'>Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.</LocalLabel>
 				</div>
-				<div class={style.options}>
+				<div cmp={true} class={style.options}>
 					<Button
+						cmp={true}
 						class={style.rejectAll}
 						invert={true}
 						onClick={onShowPurposes}
@@ -49,6 +50,7 @@ export default class Intro extends Component {
 						<LocalLabel providedValue={localization && localization.intro ? localization.intro.showPurposes : ''} localizeKey='showPurposes'>Learn more</LocalLabel>
 					</Button>
 					<Button
+						cmp={true}
 						class={style.acceptAll}
 						onClick={onAcceptAll}
 					>

--- a/src/components/popup/intro/introV2.jsx
+++ b/src/components/popup/intro/introV2.jsx
@@ -31,15 +31,16 @@ export default class IntroV2 extends Component {
     } = props;
 
     return (
-      <div class={style.intro}>
-        <div class={style.title + " primaryText"}>
+      <div cmp={true} class={style.intro}>
+        <div cmp={true} class={style.title + " primaryText"}>
           <LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
           <LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
         </div>
-        <div class={style.description + " primaryText"}>
+        <div cmp={true} class={style.description + " primaryText"}>
           <LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description' class={style.contentMessage}>Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.</LocalLabel>
           <div class={style.options}>
             <Button
+              cmp={true}
               class={style.rejectAll}
               invert={true}
               onClick={onShowPurposes}
@@ -47,6 +48,7 @@ export default class IntroV2 extends Component {
               <LocalLabel providedValue={localization && localization.intro ? localization.intro.showPurposes : ''} localizeKey='showPurposes'>Learn more</LocalLabel>
             </Button>
             <Button
+              cmp={true}
               class={style.acceptAll}
               onClick={onAcceptAll}
               >

--- a/src/components/popup/popup.jsx
+++ b/src/components/popup/popup.jsx
@@ -46,14 +46,16 @@ export default class Popup extends Component {
 
 		return (
 			<div
+				cmp={true}
 				class={style.popup}
 				style={{ display: isConsentToolShowing ? 'flex' : 'none' }}
 			>
 				<div
+					cmp={true}
 					class={style.overlay}
 					onClick={this.handleClose}
 				/>
-				<div name='content' class={style.content}>
+				<div cmp={true} name='content' class={style.content}>
 					<Panel selectedIndex={selectedPanelIndex}>
 						<Intro
 							onAcceptAll={this.onAcceptAll}

--- a/src/components/popup/popupFooter.jsx
+++ b/src/components/popup/popupFooter.jsx
@@ -50,14 +50,16 @@ export default class PopupFooter extends Component {
 
 		return (
 			<div
+				cmp={true}
 				class={style.popup}
 				style={{ display: isFooterConsentToolShowing ? 'flex' : 'none' }}
 			>
 				<div
+					cmp={true}
 					class={style.overlay}
 					onClick={this.handleClose}
 				/>
-				<div name='content' class={this.state.isActive ? style.contentClicked : style.content}>
+				<div cmp={true} name='content' class={this.state.isActive ? style.contentClicked : style.content}>
 					<Panel selectedIndex={selectedPanelIndex}>
 						<IntroV2
 							onAcceptAll={this.onAcceptAll}

--- a/src/components/switch/switch.jsx
+++ b/src/components/switch/switch.jsx
@@ -25,18 +25,20 @@ export default class Switch extends Component {
 
 		return (
 			<span
+				cmp={true}
 				class={[style.switch, props.class, isSelected ? style.isSelected : ''].join(' ')}
 				onClick={this.handleClicked}
 			>
 				<input
+					cmp={true}
 					checked={isSelected}
 					className={style.native}
 					disabled={isDisabled}
 					type='checkbox'
 				/>
-				<span class={style.visualizationContainer} style={{backgroundColor: isSelected ? color : null}} />
-				<span class={style.visualizationGlow} style={{backgroundColor: color}} />
-				<span class={style.visualizationHandle} />
+				<span cmp={true} class={style.visualizationContainer} style={{backgroundColor: isSelected ? color : null}} />
+				<span cmp={true} class={style.visualizationGlow} style={{backgroundColor: color}} />
+				<span cmp={true} class={style.visualizationHandle} />
 			</span>
 		);
 	}


### PR DESCRIPTION
I found during testing of the custom CSS on a local page that the way the CSS gets applied actually applied to the underlying page as well, so this PR introduces an attribute of `cmp` to each element so we can confidently target it with our selectors.