### PR TITLE
Allow for logo URL in config

### DIFF
--- a/src/components/app.less
+++ b/src/components/app.less
@@ -6,7 +6,7 @@
 	font-family: 'acumin-pro-wide', sans-serif;
 	font-weight: 400;
 	font-size: 16px;
-	line-height: 1.5;
+	line-height: @line-height;
 
 	* {
 		box-sizing: border-box;

--- a/src/components/popup/intro/footerV2.jsx
+++ b/src/components/popup/intro/footerV2.jsx
@@ -49,41 +49,45 @@ export default class IntroFooterV2 extends Component {
                         <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformationHeader : ''} localizeKey='footer.deviceInformationHeader' class={style.headerMessage + " primaryText"}>Information that may be used</LocalLabel>
                     </div>
 
-                    <div class={style.content}>
-                        <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformationHeader : ''} localizeKey='footer.deviceInformationHeader' class={style.message2 + " primaryText"}>Information that may be used:</LocalLabel>
-                        <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformation : ''} localizeKey='footer.deviceInformation' class={style.message + " primaryText"}>
-                            <ul>
-                                <li>Type of browser and its settings</li>
-                                <li>Information about the device's operating system</li>
-                                <li>Cookie information</li>
-                                <li>Information about other identifiers assigned to the device</li>
-                                <li>The IP address from which the device accesses a client's website or mobile application</li>
-                                <li>Information about the user's activity on that device, including web pages and mobile apps visited or used</li>
-                                <li>Information about the geographic location of the device when it accesses a website or mobile application</li>
-                            </ul>
-                        </LocalLabel>
+                    <div class={style.wrapper}>
+                        <div class={style.content}>
+                            <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformationHeader : ''} localizeKey='footer.deviceInformationHeader' class={style.message2 + " primaryText"}>Information that may be used:</LocalLabel>
+                            <LocalLabel providedValue={localization && localization.footer ? localization.footer.deviceInformation : ''} localizeKey='footer.deviceInformation' class={style.message + " primaryText"}>
+                                <ul>
+                                    <li>Type of browser and its settings</li>
+                                    <li>Information about the device's operating system</li>
+                                    <li>Cookie information</li>
+                                    <li>Information about other identifiers assigned to the device</li>
+                                    <li>The IP address from which the device accesses a client's website or mobile application</li>
+                                    <li>Information about the user's activity on that device, including web pages and mobile apps visited or used</li>
+                                    <li>Information about the geographic location of the device when it accesses a website or mobile application</li>
+                                </ul>
+                            </LocalLabel>
 
-                        <LocalLabel providedValue={localization && localization.footer ? localization.footer.purposesHeader : ''} localizeKey='footer.purposesHeader' class={style.message2 + " primaryText"}>Purposes for storing information:</LocalLabel>
-                        <ul>
-                            {store && store.vendorList && store.vendorList.purposes && store.vendorList.purposes.map((purpose) => {
-                                return <li class="primaryText">{purpose.name}</li>
-                            })}
-                        </ul>
-                    </div>
-                    <div class={style.infoFooter}>
-                            <Button
-                                class={style.rejectAll}
-                                invert={true}
-                                onClick={onShowPurposes}
-                            >
-                                <LocalLabel providedValue={localization && localization.intro ? localization.intro.showPurposes : ''} localizeKey='intro.showPurposes'>Learn more</LocalLabel>
-                            </Button>
-                            <Button
-                                class={style.acceptAll}
-                                onClick={onAcceptAll}
-                            >
-                                <LocalLabel providedValue={localization && localization.intro ? localization.intro.acceptAll : ''} localizeKey='intro.acceptAll'>OK, Continue to site</LocalLabel>
-                            </Button>
+                            <LocalLabel providedValue={localization && localization.footer ? localization.footer.purposesHeader : ''} localizeKey='footer.purposesHeader' class={style.message2 + " primaryText"}>Purposes for storing information:</LocalLabel>
+                            <ul>
+                                {store && store.vendorList && store.vendorList.purposes && store.vendorList.purposes.map((purpose) => {
+                                    return <li class="primaryText">{purpose.name}</li>
+                                })}
+                            </ul>
+                        </div>
+                        <div class={style.optionsWrapper}>
+                            <div class={style.infoFooter}>
+                                <Button
+                                    class={style.rejectAll + " " + style.button}
+                                    invert={true}
+                                    onClick={onShowPurposes}
+                                >
+                                    <LocalLabel providedValue={localization && localization.intro ? localization.intro.showPurposes : ''} localizeKey='intro.showPurposes'>Learn more</LocalLabel>
+                                </Button>
+                                <Button
+                                    class={style.acceptAll + " " + style.button}
+                                    onClick={onAcceptAll}
+                                >
+                                    <LocalLabel providedValue={localization && localization.intro ? localization.intro.acceptAll : ''} localizeKey='intro.acceptAll'>OK, Continue to site</LocalLabel>
+                                </Button>
+                            </div>
+                        </div>
                     </div>
                 </div>}
             </div>

--- a/src/components/popup/intro/footerV2.less
+++ b/src/components/popup/intro/footerV2.less
@@ -27,6 +27,7 @@
 }
 
 .footerV2 {
+    clear: both;
     margin: 0 -35px;
 }
 

--- a/src/components/popup/intro/footerV2.less
+++ b/src/components/popup/intro/footerV2.less
@@ -84,10 +84,12 @@ ul {
     }
 }
 
-.content {
+.wrapper {
     display: flex;
-    flex-direction: column;
-    overflow: hidden;
+}
+
+.content {
+    width: 80%;
     padding: 12px 24px 0px 24px;
     font-size: 15px;
     line-height: 1.25;
@@ -101,28 +103,19 @@ ul {
     content: "\ea50";
 }
 
+.optionsWrapper {
+    margin-top: auto;
+}
+
 .infoFooter {
     display: flex;
-    justify-content: flex-end;
-    align-items: flex-end;
-    padding: 0px 12px 12px 0px;
+    flex-direction: column;
+    float: right;
+    margin-bottom: 10px;
 }
 
 .button {
-    cursor: pointer;
-    outline: none;
-    padding: 0.8em;
-    background: @color-primary;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    font-size: 1em;
-    font-weight: bold;
-    text-transform: uppercase;
-    white-space: nowrap;
-    &:hover {
-        color: @color-linkColorHover;
-    }
+    margin: 5px !important;
 }
 
 .rejectAll {
@@ -133,4 +126,10 @@ ul {
 .acceptAll {
     width: 270px;
     padding: 14px 12px !important;
+}
+
+@media (max-width: 615px) {
+    .wrapper {
+        display: block !important;
+    }
 }

--- a/src/components/popup/intro/intro.jsx
+++ b/src/components/popup/intro/intro.jsx
@@ -28,32 +28,38 @@ export default class Intro extends Component {
 			onClose,
 			localization,
 			store,
-			updateCSSPrefs
+			updateCSSPrefs,
+			config
 		} = props;
 
 		return (
 			<div class={style.intro}>
-				<div class={style.title + " primaryText"}>
-					<LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
-					<LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
-				</div>
-				<div class={style.description + " primaryText"}>
-					<LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description'>Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.</LocalLabel>
-				</div>
-				<div class={style.options}>
-					<Button
-						class={style.rejectAll}
-						invert={true}
-						onClick={onShowPurposes}
-					>
-						<LocalLabel providedValue={localization && localization.intro ? localization.intro.showPurposes : ''} localizeKey='showPurposes'>Learn more</LocalLabel>
-					</Button>
-					<Button
-						class={style.acceptAll}
-						onClick={onAcceptAll}
-					>
-						<LocalLabel providedValue={localization && localization.intro ? localization.intro.acceptAll : ''} localizeKey='acceptAll'>OK, Continue to site</LocalLabel>
-					</Button>
+				<div class={style.top}>
+					{config.logoUrl &&
+						<img class={style.logo} src={config.logoUrl} />
+					}
+					<div class={style.title + " primaryText"}>
+						<LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
+						<LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
+					</div>
+					<div class={style.description + " primaryText"}>
+						<LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description'>Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.</LocalLabel>
+					</div>
+					<div class={style.options}>
+						<Button
+							class={style.rejectAll}
+							invert={true}
+							onClick={onShowPurposes}
+						>
+							<LocalLabel providedValue={localization && localization.intro ? localization.intro.showPurposes : ''} localizeKey='showPurposes'>Learn more</LocalLabel>
+						</Button>
+						<Button
+							class={style.acceptAll}
+							onClick={onAcceptAll}
+						>
+							<LocalLabel providedValue={localization && localization.intro ? localization.intro.acceptAll : ''} localizeKey='acceptAll'>Accept all</LocalLabel>
+						</Button>
+					</div>
 				</div>
 				<IntroFooter
 					onShowPurposes={onShowPurposes}

--- a/src/components/popup/intro/intro.less
+++ b/src/components/popup/intro/intro.less
@@ -13,7 +13,7 @@ div.intro {
 		.logo {
 			display: block;
 			margin: 20px auto 10px auto;
-			max-width: 30%;
+			max-width: 75%;
 			max-height: 100px;
 		}
 	}

--- a/src/components/popup/intro/intro.less
+++ b/src/components/popup/intro/intro.less
@@ -6,6 +6,17 @@ div.intro {
 	flex: 1;
 	max-height: 100%;
 
+	.top {
+		max-height: 425px;
+		overflow: scroll;
+
+		.logo {
+			display: block;
+			margin: 20px auto 10px auto;
+			max-width: 30vh;
+			max-height: 13vh;
+		}
+	}
 	.title {
 		font-size: 30px;
 		font-weight: bold;

--- a/src/components/popup/intro/intro.less
+++ b/src/components/popup/intro/intro.less
@@ -13,8 +13,8 @@ div.intro {
 		.logo {
 			display: block;
 			margin: 20px auto 10px auto;
-			max-width: 30vh;
-			max-height: 13vh;
+			max-width: 30%;
+			max-height: 100px;
 		}
 	}
 	.title {

--- a/src/components/popup/intro/introV2.jsx
+++ b/src/components/popup/intro/introV2.jsx
@@ -27,14 +27,20 @@ export default class IntroV2 extends Component {
       onClose,
       localization,
       store,
-      updateCSSPrefs
+      updateCSSPrefs,
+      config
     } = props;
 
     return (
       <div class={style.intro}>
-        <div class={style.title + " primaryText"}>
-          <LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
-          <LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
+          <div class={style.titleContainer + " primaryText"}>
+          {config.logoUrl &&
+            <img class={style.logo} src={config.logoUrl} />
+          }
+          <div class={style.title}>
+            <LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
+            <LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
+          </div>
         </div>
         <div class={style.description + " primaryText"}>
           <LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description' class={style.contentMessage}>Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.</LocalLabel>

--- a/src/components/popup/intro/introV2.jsx
+++ b/src/components/popup/intro/introV2.jsx
@@ -33,17 +33,21 @@ export default class IntroV2 extends Component {
 
     return (
       <div class={style.intro}>
-          <div class={style.titleContainer + " primaryText"}>
-          {config.logoUrl &&
-            <img class={style.logo} src={config.logoUrl} />
-          }
-          <div class={style.title}>
-            <LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
-            <LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
+        <div class={style.topWrapper}>
+          <div class={style.textWrapper}>
+            <div class={style.titleContainer + " primaryText"}>
+              {config.logoUrl &&
+                <img class={style.logo} src={config.logoUrl} />
+              }
+              <div class={style.title}>
+                <LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
+                <LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
+              </div>
+            </div>
+            <div class={style.description + " primaryText"}>
+              <LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description' class={style.contentMessage}>Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.</LocalLabel>
+            </div>
           </div>
-        </div>
-        <div class={style.description + " primaryText"}>
-          <LocalLabel providedValue={localization && localization.intro ? localization.intro.description : ''} localizeKey='description' class={style.contentMessage}>Ads help us run this site. When you use our site selected companies may access and use information on your device for various purposes including to serve relevant ads or personalised content.</LocalLabel>
           <div class={style.options}>
             <Button
               class={style.rejectAll}

--- a/src/components/popup/intro/introV2.less
+++ b/src/components/popup/intro/introV2.less
@@ -1,15 +1,30 @@
+@import '../../../style/variables';
+
 div.intro {
 padding: 0 32px;
 max-height: 100%;
 
-	.title {
+	.logo {
+		max-width: calc(calc(30px * @line-height) * 1.5);
+		max-height: calc(calc(30px * @line-height) * 1.5);
+		width: calc(calc(30px * @line-height) * 1.0);
+		height: calc(calc(30px * @line-height) * 1.0);
+		float: left;
+	}
+	.titleContainer {
 		padding: 10px 0;
 		font-size: 30px;
 		font-weight: bold;
+
+		.title {
+			padding-left: 10px;
+			float: left;
+			line-height: 1.5;
+		}
 	}
 	.description {
 		display: inline-flex;
-		padding: 10px;
+		padding: 10px 10px 10px 0px;
 	}
 	.contentMessage {
 		padding-right: 32px;

--- a/src/components/popup/intro/introV2.less
+++ b/src/components/popup/intro/introV2.less
@@ -9,28 +9,41 @@ max-height: 100%;
 		height: calc(calc(30px * @line-height) * 1.0);
 		float: left;
 	}
-	.titleContainer {
-		padding: 10px 0;
-		font-size: 30px;
-		font-weight: bold;
-
-		.title {
-			padding-left: 10px;
-			float: left;
-			line-height: 1.5;
-		}
-	}
-	.description {
+	.topWrapper {
 		display: inline-flex;
-		padding: 10px 10px 10px 0px;
+
+		.textWrapper {
+			display: flex;
+			flex-direction: column;
+
+			.titleContainer {
+				padding: 10px 0;
+				font-size: 30px;
+				font-weight: bold;
+
+				.title {
+					padding-left: 10px;
+					float: left;
+					line-height: 1.5;
+				}
+			}
+			.description {
+				padding: 10px 10px 10px 0px;
+			}
+		}
+		.options {
+			display: flex;
+			flex: 1;
+			flex-direction: column;
+			padding-top: 10px;
+
+			button {
+				margin: 5px;
+			}
+		}
 	}
 	.contentMessage {
 		padding-right: 32px;
-	}
-	.options {
-		display: flex;
-		align-items: flex-end;
-		padding: 5px;
 	}
 	.rejectAll {
 		width: 270px;
@@ -44,7 +57,37 @@ max-height: 100%;
 }
 
 @media (max-width: 800px) {
+	.topWrapper {
+		display: block !important;
+
+		.description {
+			padding: 10px !important;
+			display: block !important;
+		}
+		.options {
+			margin: 0 auto !important;
+		}
+	}
+}
+
+@media (max-width: 620px) {
 	.description {
 		display: block !important;
+	}
+	.topWrapper {
+		display: block !important;
+
+		.logo {
+			display: block;
+			margin: 0 auto;
+			width: initial !important;
+			height: initial !important;
+			max-width: 80%;
+			max-height: 100px;
+			float: none !important;
+		}
+		.options {
+			margin: 0 auto !important;
+		}
 	}
 }

--- a/src/components/popup/intro/introV2.less
+++ b/src/components/popup/intro/introV2.less
@@ -5,8 +5,6 @@ padding: 0 32px;
 max-height: 100%;
 
 	.logo {
-		max-width: calc(calc(30px * @line-height) * 1.5);
-		max-height: calc(calc(30px * @line-height) * 1.5);
 		width: calc(calc(30px * @line-height) * 1.0);
 		height: calc(calc(30px * @line-height) * 1.0);
 		float: left;

--- a/src/components/popup/popup.less
+++ b/src/components/popup/popup.less
@@ -25,7 +25,6 @@
 	height: 500px;
 	background: white;
 	display: flex;
-	align-items: center;
 	position: relative;
 	background-color: white;
 	box-shadow: 0px 0px 0px 3px @color-primary;

--- a/src/components/popup/popup.test.js
+++ b/src/components/popup/popup.test.js
@@ -15,14 +15,14 @@ describe('Popup', () => {
 	it('should render with overlay hidden', () => {
 		const store = new Store();
 		store.isConsentToolShowing = false;
-		const popup = <Popup updateCSSPrefs={() => {}} store={store} />;
+		const popup = <Popup config={{}} updateCSSPrefs={() => {}} store={store} />;
 		expect(popup).to.contain('display: none');
 	});
 
 	it('should render with overlay visible', () => {
 		const store = new Store();
 		store.isConsentToolShowing = true;
-		const popup = <Popup store={store} />;
+		const popup = <Popup config={{}} store={store} />;
 		expect(popup).to.contain('display: flex');
 	});
 
@@ -34,6 +34,7 @@ describe('Popup', () => {
 
 		let popup;
 		render(<Popup
+			config={{}}
 			updateCSSPrefs={() => {}}
 			store={store}
 			ref={ref => popup = ref}
@@ -48,11 +49,25 @@ describe('Popup', () => {
 		popup.onAcceptAll();
 	});
 
+	it('should render a logo', () => {
+		const store = new Store();
+
+		render(<Popup
+			config={{logoUrl: "https://www.example.com/image.jpg"}}
+			updateCSSPrefs={() => {}}
+			store={store}
+			ref={() => {}}
+		/>, scratch);
+
+		expect(scratch.innerHTML).to.contain(`<img class="logo" src="https://www.example.com/image.jpg">`);
+	});
+
 	it('should switch between panel states', () => {
 		const store = new Store();
 
 		let popup;
 		render(<Popup
+			config={{}}
 			updateCSSPrefs={() => {}}
 			store={store}
 			ref={ref => popup = ref}

--- a/src/docs/components/app.less
+++ b/src/docs/components/app.less
@@ -4,7 +4,7 @@ html, body, .container {
 	height: 100%;
 	margin: 0;
 	font-size: 100%;
-  	line-height: 1.5;
+	line-height: 1.5;
 	font-family: Helvetica, sans-serif;
 	color: #333;
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -19,6 +19,7 @@ const defaultConfig = {
 	testingMode: 'normal',
 	layout: null,
 	showFooterAfterSubmit: true,
+	logoUrl: null,
 	css: {
 		"color-primary": "#0a82be",
 		"color-secondary": "#eaeaea",
@@ -29,7 +30,7 @@ const defaultConfig = {
 		"color-linkColor": "#0a82be",
 		"color-table-background": "#f7f7f7",
 		"font-family": "'Helvetica Neue', Helvetica, Arial, sans-serif",
-		"custom-font-url": null
+		"custom-font-url": null,
 	},
 };
 

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -6,5 +6,6 @@
 @color-linkColor: @color-primary;
 @color-linkColorHover: #3b9bcb;
 @color-table-background: #f7f7f7;
+@line-height: 1.5;
 
 @smartphone: ~"only screen and (min-device-width : 320px) and (max-device-width : 480px)";


### PR DESCRIPTION
Closes https://github.com/digi-trust/cmp/issues/27

Example images:
**Footer style: logo is forced to be a square and is inline with text at 1.5x text height. Also the action buttons are now stacked**
<img width="1435" alt="screen shot 2018-06-08 at 8 30 26 am" src="https://user-images.githubusercontent.com/4782746/41166888-3a84609a-6af6-11e8-889e-b06561fbe126.png">
**Further example of stacked action buttons after footer expansion:**
<img width="1437" alt="screen shot 2018-06-08 at 8 31 03 am" src="https://user-images.githubusercontent.com/4782746/41166922-52f6ad04-6af6-11e8-9016-25b4504beca2.png">


**Modal style: vertically biased image, height is capped at 100px, though width is allowed to grow to 75% container width**
<img width="722" alt="screen shot 2018-06-08 at 6 39 48 am" src="https://user-images.githubusercontent.com/4782746/41161455-cb3b7c2c-6ae7-11e8-941a-d58c78c4f9bc.png">

**More representative samples:**
<img width="719" alt="screen shot 2018-06-08 at 6 41 52 am" src="https://user-images.githubusercontent.com/4782746/41161487-e9d4f5aa-6ae7-11e8-8ff6-39cf3fc933d2.png">

<img width="722" alt="screen shot 2018-06-08 at 6 42 09 am" src="https://user-images.githubusercontent.com/4782746/41161501-f6812378-6ae7-11e8-8fce-0d5f2178560f.png">

<img width="717" alt="screen shot 2018-06-08 at 6 42 17 am" src="https://user-images.githubusercontent.com/4782746/41161514-fdee8808-6ae7-11e8-9bfa-707d70f7cfba.png">
