### PR TITLE
v1.2.1 - CSS fix for logo-less CMPs

### DIFF
--- a/src/components/popup/intro/intro.jsx
+++ b/src/components/popup/intro/intro.jsx
@@ -33,7 +33,7 @@ export default class Intro extends Component {
 		} = props;
 
 		return (
-			<div class={style.intro}>
+			<div class={config.logoUrl ? style.flexColumn + " " + style.intro : style.intro}>
 				<div class={style.top}>
 					{config.logoUrl &&
 						<img class={style.logo} src={config.logoUrl} />

--- a/src/components/popup/intro/intro.less
+++ b/src/components/popup/intro/intro.less
@@ -1,6 +1,9 @@
+.flexColumn {
+	flex-direction: column;
+}
+
 div.intro {
 	display: flex;
-	flex-direction: column;
 	align-items: center;
 	padding: 0 4em;
 	flex: 1;

--- a/src/components/popup/intro/introV2.jsx
+++ b/src/components/popup/intro/introV2.jsx
@@ -39,7 +39,7 @@ export default class IntroV2 extends Component {
               {config.logoUrl &&
                 <img class={style.logo} src={config.logoUrl} />
               }
-              <div class={style.title}>
+              <div class={config.logoUrl ? style.title + " " + style.imagePadding : style.title}>
                 <LocalLabel providedValue={localization && localization.intro ? localization.intro.title : ''} localizeKey='title'>Thanks for visiting </LocalLabel>
                 <LocalLabel providedValue={localization && localization.intro ? localization.intro.domain : ''} localizeKey='domain'></LocalLabel>
               </div>

--- a/src/components/popup/intro/introV2.less
+++ b/src/components/popup/intro/introV2.less
@@ -1,5 +1,9 @@
 @import '../../../style/variables';
 
+.imagePadding {
+	padding-left: 10px;
+}
+
 div.intro {
 padding: 0 32px;
 max-height: 100%;
@@ -22,7 +26,6 @@ max-height: 100%;
 				font-weight: bold;
 
 				.title {
-					padding-left: 10px;
 					float: left;
 					line-height: 1.5;
 				}


### PR DESCRIPTION
CMPs were showing up a bit weird with regards to vertical alignment when they did not have a logo specified, so this conditionally applies CSS rules when there is a logoUrl found versus when there isn't.