### PR TITLE
v1.2.2 CSS fixes for Windows machines

### DIFF
--- a/src/components/popup/intro/intro.less
+++ b/src/components/popup/intro/intro.less
@@ -11,6 +11,7 @@ div.intro {
 
 	.top {
 		max-height: 425px;
+		margin-bottom: 75px;
 		overflow: auto;
 
 		.logo {

--- a/src/components/popup/intro/intro.less
+++ b/src/components/popup/intro/intro.less
@@ -11,7 +11,7 @@ div.intro {
 
 	.top {
 		max-height: 425px;
-		overflow: scroll;
+		overflow: auto;
 
 		.logo {
 			display: block;


### PR DESCRIPTION
Windows machines are seeing scrollbars rendered even when they don't need it. This is a small CSS change with a safeguard to make sure extremely long intro text doesn't take over the footer at the bottom.