### PR TITLE
Issue #34 route a redirect through digitru.st on save

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
   "globalConsentLocation": "https://cdn.digitrust.mgr.consensu.org/1/portal.html",
   "globalVendorListLocation": "https://vendorlist.consensu.org/vendorlist.json",
   "localizedVendorListProvider": "https://vendorlist.consensu.org/purposes-${consentLanguage}.json",
+  "digitrustRedirectLocation": "https://cdn.digitru.st/prod/1.5.10/redirect.html?redirect=",
   "countryCodes": [
     "GB",
     "DE",

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -85,6 +85,14 @@ export default class App extends Component {
 		notify('onSubmit');
 		store.toggleConsentToolShowing(false);
 		store.toggleFooterShowing(true);
+		if (this.props.config.digitrust.redirects === true) {
+			window.__cmp('getVendorConsents', [64], function(result) {
+				if (result && result['vendorConsents'] && (result['vendorConsents']['64'] === true)) {
+					document.location = "//cdn.digitru.st/prod/1.5.10/redirect.html?redirect=" +
+						encodeURIComponent(window.location.href);
+				}
+			});
+		}
 	};
 
 	updateState = (store) => {

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -80,7 +80,7 @@ export default class App extends Component {
 	};
 
 	onSave = () => {
-		const { store, config, notify } = this.props;
+		const { store, notify } = this.props;
 		store.persist();
 		notify('onSubmit');
 		store.toggleConsentToolShowing(false);

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -85,14 +85,6 @@ export default class App extends Component {
 		notify('onSubmit');
 		store.toggleConsentToolShowing(false);
 		store.toggleFooterShowing(true);
-		if (config.digitrust.redirects === true) {
-			window.__cmp('getVendorConsents', [64], function(result) {
-				if (result && result['vendorConsents'] && (result['vendorConsents']['64'] === true)) {
-					document.location = config.digitrustRedirectUrl +
-						encodeURIComponent(window.location.href);
-				}
-			});
-		}
 	};
 
 	updateState = (store) => {

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -80,15 +80,15 @@ export default class App extends Component {
 	};
 
 	onSave = () => {
-		const { store, notify } = this.props;
+		const { store, config, notify } = this.props;
 		store.persist();
 		notify('onSubmit');
 		store.toggleConsentToolShowing(false);
 		store.toggleFooterShowing(true);
-		if (this.props.config.digitrust.redirects === true) {
+		if (config.digitrust.redirects === true) {
 			window.__cmp('getVendorConsents', [64], function(result) {
 				if (result && result['vendorConsents'] && (result['vendorConsents']['64'] === true)) {
-					document.location = "//cdn.digitru.st/prod/1.5.10/redirect.html?redirect=" +
+					document.location = config.digitrustRedirectUrl +
 						encodeURIComponent(window.location.href);
 				}
 			});

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -16,6 +16,7 @@ const defaultConfig = {
 		noConsentGiven: 30,
 	},
 	geoIPVendor: 'https://cmp.digitru.st/1/geoip.json',
+	digitrustRedirectUrl: metadata.digitrustRedirectLocation,
 	testingMode: 'normal',
 	blockBrowsing: true,
 	layout: null,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -36,14 +36,15 @@ const defaultConfig = {
 	},
 	digitrust: {
 		redirects: false
-	},
+	}
 };
 
 class Config {
 	constructor() {
 		this.individualOverwritesAllowed = {
-			"repromptOptions": true,
-			"css": true
+			repromptOptions: true,
+			css: true,
+			digitrust: true
 		};
 
 		this.update(defaultConfig);

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -33,6 +33,9 @@ const defaultConfig = {
 		"font-family": "'Helvetica Neue', Helvetica, Arial, sans-serif",
 		"custom-font-url": null,
 	},
+	digitrust: {
+		redirects: false
+	},
 };
 
 class Config {

--- a/src/lib/config.test.js
+++ b/src/lib/config.test.js
@@ -9,5 +9,7 @@ describe('config', () => {
 		config.update({ css: { 'font-family': 'MonoType' }});
 		expect(config.css['font-family']).to.equal('MonoType');
 		expect(config.css['color-primary']).to.equal('#0a82be');
+		config.update({ digitrust: { some: 'prop' }});
+		expect(config.digitrust.redirects).to.be.false;
 	});
 });

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -48,6 +48,20 @@ export function init(configUpdates) {
 				// Execute any previously queued command
 				cmp.commandQueue = commandQueue;
 
+				// set cookies on digitrust domain after consent submitted
+				const { addEventListener, getVendorConsents } = cmp.commands;
+				if (config.digitrust.redirects) {
+					addEventListener('consentStringUpdated', digitrustRedirect);
+				}
+
+				function digitrustRedirect() {
+					getVendorConsents([64], (result) => {
+						if (result && result.vendorConsents && result.vendorConsents[64]) {
+							window.location.replace(`${config.digitrustRedirectUrl}${encodeURIComponent(window.location.href)}`);
+						}
+					});
+				}
+
 				return checkIfUserInEU(config.geoIPVendor, (response) => {
 					cmp.gdprApplies = response.applies;
 					cmp.gdprAppliesLanguage = response.language;


### PR DESCRIPTION
By default this behavior is disabled.

To enable, set this property within `cmp.config`
```
digitrust: { redirects: true }
```

When enabled, the `onSave()` event triggers a redirect through `https://cdn.digitru.st/prod/1.5.10/redirect.html?redirect={window.location.href}`.